### PR TITLE
Add step to vendor dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV BDB_PREFIX $BITCOIN_DIR/db4
 RUN $BITCOIN_DIR/autogen.sh \
   && $BITCOIN_DIR/configure --without-gui BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
 
-RUN make && make install
+RUN make && make install && make update
 
 USER oneledger
 


### PR DESCRIPTION
Forgot to add this in the Dockerfile, after this the make targets should be able to run right after running `docker build` 