### PR TITLE
Move away from type aliases for PublicKey and PrivateKey

### DIFF
--- a/node/app/register.go
+++ b/node/app/register.go
@@ -15,7 +15,7 @@ import (
 
 // Register Identities and Accounts from the user.
 func RegisterLocally(app *Application, name string, scope string, chain data.ChainType,
-	publicKey id.ED25519PublicKey, privateKey id.ED25519PrivateKey) bool {
+	publicKey id.PublicKeyED25519, privateKey id.PrivateKeyED25519) bool {
 
 	status := false
 

--- a/node/id/account.go
+++ b/node/id/account.go
@@ -228,8 +228,8 @@ type AccountBase struct {
 	Name string         `json:"name"`
 
 	// TODO: Should handle key polymorphism properly..
-	PublicKey  ED25519PublicKey  `json:"publicKey"`
-	PrivateKey ED25519PrivateKey `json:"privateKey"`
+	PublicKey  PublicKeyED25519  `json:"publicKey"`
+	PrivateKey PrivateKeyED25519 `json:"privateKey"`
 }
 
 func init() {
@@ -240,7 +240,7 @@ func init() {
 }
 
 // Create a new account for a given chain
-func NewAccount(newType data.ChainType, name string, key ED25519PublicKey, priv ED25519PrivateKey) Account {
+func NewAccount(newType data.ChainType, name string, key PublicKeyED25519, priv PrivateKeyED25519) Account {
 	switch newType {
 
 	case data.ONELEDGER:

--- a/node/id/keys.go
+++ b/node/id/keys.go
@@ -6,6 +6,7 @@
 package id
 
 import (
+	"bytes"
 	"errors"
 
 	"golang.org/x/crypto/bcrypt"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/Oneledger/protocol/node/log"
 	"github.com/Oneledger/protocol/node/serial"
-	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
@@ -41,44 +41,124 @@ func (accountKey AccountKey) Bytes() []byte {
 }
 
 // NewAccountKey hashes the public key to get a unique hash that can act as a key
-func NewAccountKey(key ED25519PublicKey) AccountKey {
-	hasher := ripemd160.New()
-	hasher.Write(key.Bytes())
-
-	return hasher.Sum(nil)
+func NewAccountKey(key PublicKeyED25519) AccountKey {
+	return key.Address()
 }
 
-type PublicKey = crypto.PubKey
-type PrivateKey = crypto.PrivKey
+type PublicKey interface {
+	Address() []byte
+	Bytes() []byte
+	VerifyBytes(msg []byte, sig []byte) bool
+	Equals(PublicKey) bool
+}
 
-type ED25519PublicKey = ed25519.PubKeyEd25519
-type ED25519PrivateKey = ed25519.PrivKeyEd25519
+type PrivateKey interface {
+	Bytes() []byte
+	Sign([]byte) ([]byte, error)
+	PubKey() PublicKey
+	Equals(PrivateKey) bool
+}
 
-type SECP256K1PublicKey = secp256k1.PubKeySecp256k1
-type SECP256K1PrivateKey = secp256k1.PrivKeySecp256k1
+type PublicKeyED25519 ed25519.PubKeyEd25519
+type PrivateKeyED25519 ed25519.PrivKeyEd25519
+
+type PublicKeySECP256K1 secp256k1.PubKeySecp256k1
+type PrivateKeySECP256K1 secp256k1.PrivKeySecp256k1
 
 func init() {
 	serial.Register(NilPublicKey())
 	serial.Register(NilPrivateKey())
-	serial.Register(SECP256K1PublicKey{})
-	serial.Register(SECP256K1PrivateKey{})
+	serial.Register(PublicKeySECP256K1{})
+	serial.Register(PrivateKeySECP256K1{})
 }
 
-func NilPublicKey() ED25519PublicKey {
-	return ED25519PublicKey{}
+func NilPublicKey() PublicKeyED25519 {
+	return PublicKeyED25519{}
 }
 
-func NilPrivateKey() ED25519PrivateKey {
-	return ED25519PrivateKey{}
+func NilPrivateKey() PrivateKeyED25519 {
+	return PrivateKeyED25519{}
 }
 
-func GenerateKeys(secret []byte) (ED25519PrivateKey, ED25519PublicKey) {
+// Public Keys
+// --------------------------------------------------
+
+func (k PublicKeyED25519) Bytes() []byte {
+	return k[:]
+}
+
+// Address hashes the key with a RIPEMD-160 hash
+func (k PublicKeyED25519) Address() []byte {
+	return hash(k)
+}
+
+func (k PublicKeyED25519) VerifyBytes(msg []byte, sig []byte) bool {
+	return ed25519.PubKeyEd25519(k).VerifyBytes(msg, sig)
+}
+
+func (k PublicKeyED25519) Equals(key PublicKey) bool {
+	return bytes.Equal(k.Bytes(), key.Bytes())
+}
+
+func (k PublicKeySECP256K1) Bytes() []byte {
+	return k[:]
+}
+
+func (k PublicKeySECP256K1) Address() []byte {
+	return hash(k)
+}
+
+func (k PublicKeySECP256K1) VerifyBytes(msg []byte, sig []byte) bool {
+	return secp256k1.PubKeySecp256k1(k).VerifyBytes(msg, sig)
+}
+
+func (k PublicKeySECP256K1) Equals(key PublicKey) bool {
+	return bytes.Equal(k.Bytes(), key.Bytes())
+}
+
+// Private keys
+//--------------------------------------------------
+func (k PrivateKeyED25519) Bytes() []byte {
+	return k[:]
+}
+
+func (k PrivateKeyED25519) Sign(msg []byte) ([]byte, error) {
+	return ed25519.PrivKeyEd25519(k).Sign(msg)
+}
+
+func (k PrivateKeyED25519) PubKey() PublicKey {
+	p := ed25519.PrivKeyEd25519(k).PubKey().(ed25519.PubKeyEd25519)
+	return PublicKeyED25519(p)
+}
+
+func (k PrivateKeyED25519) Equals(key PrivateKey) bool {
+	return bytes.Equal(k.Bytes(), key.Bytes())
+}
+
+func (k PrivateKeySECP256K1) Bytes() []byte {
+	return k[:]
+}
+
+func (k PrivateKeySECP256K1) Sign(msg []byte) ([]byte, error) {
+	return secp256k1.PrivKeySecp256k1(k).Sign(msg)
+}
+
+func (k PrivateKeySECP256K1) PubKey() PublicKey {
+	p := secp256k1.PrivKeySecp256k1(k).PubKey().(ed25519.PubKeyEd25519)
+	return PublicKeyED25519(p)
+}
+
+func (k PrivateKeySECP256K1) Equals(key PrivateKey) bool {
+	return bytes.Equal(k.Bytes(), key.Bytes())
+}
+
+func GenerateKeys(secret []byte) (PrivateKeyED25519, PublicKeyED25519) {
 	// TODO: Should be configurable
 	private, public, err := generateKeys(secret, ED25519)
 	if err != nil {
 		log.Fatal("Key Generation Failed")
 	}
-	return private.(ED25519PrivateKey), public.(ED25519PublicKey)
+	return private.(PrivateKeyED25519), public.(PublicKeyED25519)
 }
 
 func generateKeys(secret []byte, algorithm KeyAlgorithm) (PrivateKey, PublicKey, error) {
@@ -90,18 +170,24 @@ func generateKeys(secret []byte, algorithm KeyAlgorithm) (PrivateKey, PublicKey,
 
 	case ED25519:
 		private := ed25519.GenPrivKeyFromSecret(hash)
-		log.Info("Generate", "private", private)
-		public := private.PubKey()
-		return ED25519PrivateKey(private), public, nil
+		public := private.PubKey().(ed25519.PubKeyEd25519)
+		return PrivateKeyED25519(private), PublicKeyED25519(public), nil
 
 	case SECP256K1:
 		// NOTE: secret should be the output of a KDF like bcrypt,
 		// if it's derived from user input.
 		private := secp256k1.GenPrivKeySecp256k1(hash)
-		public := private.PubKey()
-		return SECP256K1PrivateKey(private), public, nil
+		public := private.PubKey().(secp256k1.PubKeySecp256k1)
+		return PrivateKeySECP256K1(private), PublicKeySECP256K1(public), nil
 	}
 	return NilPrivateKey(), NilPublicKey(), errors.New("Unknown Algorithm: " + string(algorithm))
+}
+
+func hash(k PublicKey) []byte {
+	hasher := ripemd160.New()
+	hasher.Write(k.Bytes())
+
+	return hasher.Sum(nil)
 }
 
 //	salt := cytpo.CRandBytes(16)

--- a/node/id/serial_test.go
+++ b/node/id/serial_test.go
@@ -68,7 +68,7 @@ func TestIdentity(t *testing.T) {
 }
 
 type KeyBase struct {
-	Key ED25519PublicKey
+	Key PublicKeyED25519
 }
 
 func init() {


### PR DESCRIPTION
Methods on these types are still wrappers around tendermint types, but not we can extend these types with new methods