### PR TITLE
Wallet panic

### DIFF
--- a/data/accounts/wallet.go
+++ b/data/accounts/wallet.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/Oneledger/protocol/config"
 	"github.com/Oneledger/protocol/data/keys"
@@ -32,6 +33,8 @@ type WalletStore struct {
 	store storage.SessionedStorage
 
 	accounts []storage.StoreKey
+
+	sync.Mutex
 }
 
 // WalletStore satisfies the Wallet interface
@@ -61,6 +64,9 @@ func (ws WalletStore) Accounts() []Account {
 }
 
 func (ws *WalletStore) Add(account Account) error {
+	ws.Lock()
+	defer ws.Unlock()
+
 	session := ws.store.BeginSession()
 
 	exist := session.Exists(account.Address().Bytes())
@@ -81,6 +87,9 @@ func (ws *WalletStore) Add(account Account) error {
 }
 
 func (ws *WalletStore) Delete(account Account) error {
+	ws.Lock()
+	defer ws.Unlock()
+
 	session := ws.store.BeginSession()
 
 	exist := session.Exists(account.Address().Bytes())
@@ -138,6 +147,7 @@ func NewWallet(config config.Server, dbDir string) Wallet {
 	return &WalletStore{
 		store,
 		accounts,
+		sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
    fix wallet panic on concurrent add accounts
    
    if a set followed by commit is called on the iavl.MutableTree concurrently. The earlier commit saves the un-commited data. If the later
    commit has no changes to commit it just panics.
    
    Only way around this is calling the set and commit in an exclusive lock.
