### PR TITLE
travis ci deploy hot fix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: go
 go:
 - 1.11.x
+addons:
+  apt:
+    update: true
+    packages:
+    - libleveldb-dev
+    - libsnappy-dev
 before_script:
 - export OLDATA=$GOPATH/test
 - export OLROOT=$GOPATH/src/github.com/Oneledger
@@ -19,8 +25,8 @@ before_script:
 - cd $TRAVIS_BUILD_DIR && git clone git@github.com:Oneledger/infrastructure.git --branch
   master
 script:
-- cd $OLROOT/protocol && make update install
 - cd $OLROOT/protocol && make fulltest
+- cd $OLROOT/protocol && make update install_c
 before_deploy:
 - sudo apt-get update && sudo apt-get install unzip python python-pip
 - sudo pip install netaddr ipaddr cryptography==2.2.2 ansible


### PR DESCRIPTION
GOPATH environment explictly specified


Revert "GOPATH environment explictly specified"

This reverts commit bcf1ee6e405b3c2bc8f3a961f59d3073fe251780.

execute fulltest before install_c

