### PR TITLE
Olp 629 & olp 633

### DIFF
--- a/action/btc/add_signature.go
+++ b/action/btc/add_signature.go
@@ -160,7 +160,8 @@ func runAddSignature(ctx *action.Context, tx action.RawTx) (bool, action.Respons
 		return false, action.Response{Log: errors.Wrap(err, "error parsing btc txn").Error()}
 	}
 
-	if !(tracker.ProcessType == bitcoin.ProcessTypeLock && len(btcTx.TxIn) == 1) {
+	isFirstLock := tracker.CurrentTxId == nil
+	if !isFirstLock {
 
 		pk, err := btcec.ParsePubKey(addSignature.ValidatorPubKey, btcec.S256())
 		sign, err := btcec.ParseSignature(addSignature.BTCSignature, btcec.S256())

--- a/action/btc/add_signature.go
+++ b/action/btc/add_signature.go
@@ -160,6 +160,7 @@ func runAddSignature(ctx *action.Context, tx action.RawTx) (bool, action.Respons
 		return false, action.Response{Log: errors.Wrap(err, "error parsing btc txn").Error()}
 	}
 
+	// individual signature verification
 	isFirstLock := tracker.CurrentTxId == nil
 	if !isFirstLock {
 
@@ -189,11 +190,9 @@ func runAddSignature(ctx *action.Context, tx action.RawTx) (bool, action.Respons
 	if err != nil {
 		return false, action.Response{Log: fmt.Sprintf("error adding signature: %s, error: %s", addSignature.TrackerName, err.Error())}
 	}
-	tracker.Multisig.GetSignaturesInOrder()
 
 	if tracker.HasEnoughSignatures() {
 		tracker.State = bitcoin.BusyScheduleBroadcasting
-
 	}
 
 	err = ctx.BTCTrackers.SetTracker(addSignature.TrackerName, tracker)

--- a/action/btc/check_finality.go
+++ b/action/btc/check_finality.go
@@ -224,14 +224,15 @@ func runReportFinalityMint(ctx *action.Context, tx action.RawTx) (bool, action.R
 		}
 
 		oBTCCoin := curr.NewCoinFromUnit(tracker.ProcessBalance - tracker.CurrentBalance)
+
 		err = ctx.Balances.AddToAddress(f.OwnerAddress, oBTCCoin)
 		if err != nil {
 			ctx.Logger.Error(err)
 			return false, action.Response{Log: "error adding oBTC to address"}
 		}
 
-		tally := keys.Address(lockBalanceAddress)
-		err = ctx.Balances.AddToAddress(tally, oBTCCoin)
+		circulation := keys.Address(lockBalanceAddress)
+		err = ctx.Balances.AddToAddress(circulation, oBTCCoin)
 		if err != nil {
 			ctx.Logger.Error(err)
 			return false, action.Response{Log: "error adding oBTC to address"}

--- a/action/btc/const.go
+++ b/action/btc/const.go
@@ -6,5 +6,5 @@ package btc
 
 const (
 	totalBTCSupply     = 1000000000 // 10 BTC
-	lockBalanceAddress = "13371337"
+	lockBalanceAddress = "oneledgerBtcCirculation"
 )

--- a/action/btc/failed_broadcast_reset.go
+++ b/action/btc/failed_broadcast_reset.go
@@ -23,7 +23,9 @@ type FailedBroadcastReset struct {
 }
 
 func (fbr *FailedBroadcastReset) Signers() []action.Address {
-	panic("implement me")
+	return []action.Address{
+		fbr.ValidatorAddress,
+	}
 }
 
 func (fbr *FailedBroadcastReset) Type() action.Type {
@@ -170,7 +172,7 @@ func runBroadcastFailureReset(ctx *action.Context, tx action.RawTx) (bool, actio
 	if len(tracker.ResetVotes) < votesThresholdForReset {
 		err = ctx.BTCTrackers.SetTracker(fbr.TrackerName, tracker)
 		if err != nil {
-			return false, action.Response{Log: "tracker not ready for finalizing"}
+			return false, action.Response{Log: "failed to save tracker"}
 		}
 
 		return true, action.Response{
@@ -191,6 +193,11 @@ func runBroadcastFailureReset(ctx *action.Context, tx action.RawTx) (bool, actio
 
 	tracker.FinalityVotes = []keys.Address{}
 	tracker.ResetVotes = []keys.Address{}
+
+	err = ctx.BTCTrackers.SetTracker(fbr.TrackerName, tracker)
+	if err != nil {
+		return false, action.Response{Log: "failed to save tracker"}
+	}
 
 	return true, action.Response{Tags: fbr.Tags()}
 }

--- a/action/btc/helper.go
+++ b/action/btc/helper.go
@@ -1,0 +1,79 @@
+/*
+
+ */
+
+package btc
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+
+	"github.com/Oneledger/protocol/data/bitcoin"
+)
+
+func ValidateExtLockStructure(tracker *bitcoin.Tracker, tx *wire.MsgTx, params *chaincfg.Params) bool {
+
+	// Validate outputs
+
+	// Tx out should be single or two at a time
+	if len(tx.TxOut) > 2 || len(tx.TxOut) < 1 {
+		return false
+	}
+
+	// tracker ProcessLockScriptAddress should be equal to txout address
+	if !bytes.Equal(tx.TxOut[0].PkScript, tracker.ProcessLockScriptAddress) {
+		return false
+	}
+
+	// if there is return address is present
+	if len(tx.TxOut) == 2 {
+
+		// it must be a valid btc address
+		// TODO
+
+	}
+
+	// Validate Inputs
+
+	// if this is not a first transaction for tracker
+	if tracker.CurrentTxId != nil {
+
+		if len(tx.TxIn) < 2 {
+			return false
+		}
+
+		// then the first input should be tracker balance
+		if !tx.TxIn[0].PreviousOutPoint.Hash.IsEqual(tracker.CurrentTxId) {
+			return false
+		}
+
+		// all user inputs must be signed
+		for i := range tx.TxIn {
+			if i == 0 {
+				continue
+			}
+
+			if len(tx.TxIn[i].SignatureScript) == 0 {
+				return false
+			}
+		}
+
+	} else {
+		// if this is the first transaction for the tracker
+
+		if len(tx.TxIn) < 1 {
+			return false
+		}
+
+		// all user inputs must be signed
+		for i := range tx.TxIn {
+			if len(tx.TxIn[i].SignatureScript) == 0 {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/chains/bitcoin/validation.go
+++ b/chains/bitcoin/validation.go
@@ -173,9 +173,9 @@ func EstimateTxSizeBeforeUserSign(tx *wire.MsgTx, isFirstLock bool) int {
 
 	if isFirstLock {
 
-		return tx.SerializeSize() + inputSigsSize
+		return tx.SerializeSize() + inputSigsSize + 20
 	}
 
 	sigScriptSize := 46 + 74*6 + 34*8
-	return tx.SerializeSize() + sigScriptSize + inputSigsSize
+	return tx.SerializeSize() + sigScriptSize + inputSigsSize + 20
 }

--- a/client/request_types.go
+++ b/client/request_types.go
@@ -183,18 +183,23 @@ type SignRawTxResponse struct {
 
 type BTCLockRequest struct {
 	Txn         []byte        `json:"txn"`
-	Signature   []byte        `json:"signature"`
 	Address     keys.Address  `json:"address"`
 	TrackerName string        `json:"tracker_name"`
 	GasPrice    action.Amount `json:"gasprice"`
 	Gas         int64         `json:"gas"`
 }
 
-type BTCLockPrepareRequest struct {
-	Hash    string `json:"hash"`
-	Index   uint32 `json:"index"`
-	FeesBTC int64  `json:"fees_btc"`
+type InputTransaction struct {
+	Hash  string `json:"hash"`
+	Index uint32 `json:"index"`
 }
+type BTCLockPrepareRequest struct {
+	Inputs           []InputTransaction `json:"inputs"`
+	AmountSatoshi    int64              `json:"amount"`
+	FeeRate          int64              `json:"fee_rate"`
+	ReturnAddressStr string             `json:"return_address"`
+}
+
 type BTCLockPrepareResponse struct {
 	Txn         string `json:"txn"`
 	TrackerName string `json:"tracker_name"`

--- a/client/request_types.go
+++ b/client/request_types.go
@@ -242,3 +242,10 @@ type CurrencyBalanceReply struct {
 	// The height when this balance was recorded
 	Height int64 `json:"height"`
 }
+
+type EmptyRequest struct {
+}
+
+type MaxTrackerBalanceReply struct {
+	MaxBalance int64 `json:"max_balance"`
+}

--- a/cmd/olclient/tracker.go
+++ b/cmd/olclient/tracker.go
@@ -37,7 +37,6 @@ func TrackerNode(cmd *cobra.Command, args []string) {
 		logger.Fatal(err)
 	}
 
-	// assuming we have public key
 	bal, err := fullnode.GetTracker(trackerArgs.name)
 	if err != nil {
 		logger.Fatal("error in getting balance", err)

--- a/data/bitcoin/store.go
+++ b/data/bitcoin/store.go
@@ -119,7 +119,6 @@ func (ts *TrackerStore) GetTrackerForRedeem() (*Tracker, error) {
 			highestAmount = d.CurrentBalance
 		}
 
-		// return false
 		return false
 	})
 
@@ -128,6 +127,34 @@ func (ts *TrackerStore) GetTrackerForRedeem() (*Tracker, error) {
 	}
 
 	return tempTracker, nil
+}
+
+func (ts *TrackerStore) GetMaxAvailableBalance() int64 {
+
+	var highestAmount int64 = -1
+	var tempTracker *Tracker = nil
+
+	ts.Iterate(func(k, v []byte) bool {
+
+		d := &Tracker{}
+		err := ts.szlr.Deserialize(v, d)
+		if err != nil {
+			return false
+		}
+
+		if d.IsAvailable() && d.GetBalance() > highestAmount {
+			tempTracker = d
+			highestAmount = d.CurrentBalance
+		}
+
+		return false
+	})
+
+	if tempTracker == nil {
+		return 0
+	}
+
+	return tempTracker.CurrentBalance
 }
 
 func (ts *TrackerStore) Iterate(fn func(k, v []byte) bool) {

--- a/data/bitcoin/tracker.go
+++ b/data/bitcoin/tracker.go
@@ -47,8 +47,12 @@ type Tracker struct {
 	// State tracks the current state of the tracker, Also used for locking distributed access
 	State TrackerState `json:"state"`
 
-	CurrentTxId              *chainhash.Hash
-	CurrentBalance           int64
+	// Is the transaction ID of the latest UTXO that has all the tracker bitcoin
+	CurrentTxId *chainhash.Hash
+
+	// the balance of the latest UTXO in satoshi (10^-8 BTC)
+	CurrentBalance int64
+
 	CurrentLockScriptAddress []byte
 
 	ProcessTxId              *chainhash.Hash
@@ -59,8 +63,11 @@ type Tracker struct {
 	ProcessOwner keys.Address
 	ProcessType  int
 
+	// Validator addresses who have voted to finalize the current in process transaction
 	FinalityVotes []keys.Address
-	ResetVotes    []keys.Address
+
+	// Validator addresses who have voted to reset the current in process transaction
+	ResetVotes []keys.Address
 }
 
 func NewTracker(lockScriptAddress []byte, m int, signers []keys.Address) (*Tracker, error) {

--- a/data/keys/btc_multisig.go
+++ b/data/keys/btc_multisig.go
@@ -124,7 +124,7 @@ func (m BTCMultiSig) HasAddressSigned(addr Address) bool {
 		}
 	}
 
-	if index > len(m.Signers) {
+	if index >= len(m.Signatures) {
 		return false
 	}
 

--- a/event/btc_broadcast.go
+++ b/event/btc_broadcast.go
@@ -107,8 +107,10 @@ func (j *JobBTCBroadcast) DoMyJob(ctxI interface{}) {
 	}
 
 	opt := ctx.Trackers.GetConfig()
+
+	isFirstLock := tracker.CurrentTxId == nil
 	cd := bitcoin.NewChainDriver(opt.BlockCypherToken)
-	lockTx = cd.AddLockSignature(tracker.ProcessUnsignedTx, sigScript)
+	lockTx = cd.AddLockSignature(tracker.ProcessUnsignedTx, sigScript, isFirstLock)
 
 	buf := bytes.NewBuffer([]byte{})
 	err = lockTx.Serialize(buf)
@@ -124,7 +126,7 @@ func (j *JobBTCBroadcast) DoMyJob(ctxI interface{}) {
 
 	ctx.Logger.Debug(hex.EncodeToString(txBytes))
 
-	if !(len(lockTx.TxIn) == 1 && tracker.ProcessType == bitcoin2.ProcessTypeLock) {
+	if !isFirstLock {
 
 		vm, err := txscript.NewEngine(tracker.CurrentLockScriptAddress, lockTx, 0, txscript.StandardVerifyFlags, nil, nil, tracker.CurrentBalance)
 		if err != nil {

--- a/event/btc_broadcast.go
+++ b/event/btc_broadcast.go
@@ -104,6 +104,7 @@ func (j *JobBTCBroadcast) DoMyJob(ctxI interface{}) {
 	sigScript, err := builder.Script()
 	if err != nil {
 		ctx.Logger.Error("error in building sig script", err)
+		return
 	}
 
 	opt := ctx.Trackers.GetConfig()
@@ -126,6 +127,7 @@ func (j *JobBTCBroadcast) DoMyJob(ctxI interface{}) {
 
 	ctx.Logger.Debug(hex.EncodeToString(txBytes))
 
+	// verify multisig of validators
 	if !isFirstLock {
 
 		vm, err := txscript.NewEngine(tracker.CurrentLockScriptAddress, lockTx, 0, txscript.StandardVerifyFlags, nil, nil, tracker.CurrentBalance)

--- a/event/eth_broadcast.go
+++ b/event/eth_broadcast.go
@@ -76,6 +76,7 @@ func (job *JobETHBroadcast) DoMyJob(ctx interface{}) {
 	_, err = cd.BroadcastTx(tx)
 	if err != nil {
 		ethCtx.Logger.Error("Error in transaction broadcast : ", job.GetJobID(), err)
+
 		return
 	}
 

--- a/scripts/btc/lock/main.go
+++ b/scripts/btc/lock/main.go
@@ -9,19 +9,27 @@ import (
 	"encoding/hex"
 	"fmt"
 	"time"
+
+	"github.com/Oneledger/protocol/client"
 )
 
 func main() {
-	sourceBTCHash := "49182752c27922a454c3a128377b68c636763b049307c0789168791bd71f05c2"
-	sourceBTCIndex := 0
-	wif := "cNVonQDXYShV3PJLHbz6bEs4qkKm6smRUXuYtD2uMseiUubBB25j"
 
-	txn, tname := prepareLock(sourceBTCHash, sourceBTCIndex)
+	sourceBTCHash := "b7c8d66068fccecccd2a9b29bf59fc5eb2f4117378fe53791dc3ee618077d5df"
+	var sourceBTCIndex uint32 = 0
+
+	sourceBTCHash2 := "232a164b54952dbcadb287608500463cd75e6e44d9a936e5ff6cb88edb74f887"
+	var sourceBTCIndex2 uint32 = 1
+
+	wif := "cPwDvkefgLhtWiMJYapEm4MuKhxAiRDjNFZSUHkenChAZVooaVr5"
+
+	txn, tname := prepareLock(sourceBTCHash, sourceBTCIndex, sourceBTCHash2, sourceBTCIndex2,
+		1200000, 30, "mkW45toPFaa1uyNGV4TXEWWCxyuDC7BbKG")
 	fmt.Println("Received response of PrepareLock")
 	fmt.Println("Tracker for lock: ", tname)
 	fmt.Println("BTC Unsigned Txn: ", hex.EncodeToString(txn))
 
-	time.Sleep(30 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	fmt.Println(hex.EncodeToString(txn))
 	// os.Exit(1)
@@ -29,9 +37,12 @@ func main() {
 	addrs := addressess()
 	fmt.Println("Will lock to OLT Address: ", addrs[0])
 
-	btcSignature := btcSign(txn, wif)
-	rawTx := addSignature(base64.StdEncoding.EncodeToString(txn),
-		base64.StdEncoding.EncodeToString(btcSignature),
+	signedTxn := btcSign(txn, wif, 0)
+	fmt.Println(hex.EncodeToString(signedTxn), "======================")
+	signedTxn = btcSign(signedTxn, wif, 1)
+	fmt.Println(hex.EncodeToString(signedTxn), "======================")
+
+	rawTx := addSignature(base64.StdEncoding.EncodeToString(signedTxn),
 		addrs[0], tname)
 
 	signed, signer := sign(base64.StdEncoding.EncodeToString(rawTx), addrs[0])
@@ -44,16 +55,24 @@ func main() {
 	fmt.Println(result)
 }
 
-func prepareLock(txHash string, index int) ([]byte, string) {
+func prepareLock(txHash string, index uint32, txHash2 string, index2 uint32, amount int64, feeRate int64, return_address string) ([]byte, string) {
+
+	inputs := []client.InputTransaction{
+		{txHash, index},
+		{txHash2, index2},
+	}
+
 	params := map[string]interface{}{
-		"hash":     txHash,
-		"index":    index,
-		"fees_btc": 10000,
+		"inputs":         inputs,
+		"amount":         amount,
+		"fee_rate":       feeRate,
+		"return_address": return_address,
 	}
 	resp, err := makeRPCcall("btc.PrepareLock", params)
 	if err != nil {
 		panic(err)
 	}
+	fmt.Println(resp)
 
 	txnHex, _ := resp.Result["txn"].(string)
 	txn, err := hex.DecodeString(txnHex)
@@ -88,10 +107,9 @@ func addressess() []string {
 	return strs
 }
 
-func addSignature(txn, sign, addr, trackerName string) []byte {
+func addSignature(txn, addr, trackerName string) []byte {
 	params := map[string]interface{}{
 		"txn":          txn,
-		"signature":    sign,
 		"address":      addr,
 		"tracker_name": trackerName,
 		"gasprice": map[string]interface{}{

--- a/service/btc/prepare_redeem.go
+++ b/service/btc/prepare_redeem.go
@@ -40,7 +40,7 @@ func (s *Service) PrepareRedeem(args client.BTCRedeemRequest, reply *client.BTCR
 
 	userAddress, err := btcutil.DecodeAddress(args.BTCAddress, cfg.BTCParams)
 	if err != nil {
-		return codes.ErrBadBTCAddress
+		return codes.ErrBadBTCAddress.Wrap(err)
 	}
 
 	btcAddr, err := txscript.PayToAddrScript(userAddress)

--- a/service/btc/query.go
+++ b/service/btc/query.go
@@ -26,7 +26,7 @@ func (s *Service) GetTracker(args client.BTCGetTrackerRequest, reply *client.BTC
 
 func (s *Service) GetMaxTrackerBalance(args client.EmptyRequest, reply *client.MaxTrackerBalanceReply) error {
 
-	reply.MaxBalance = s.trackerStore.GetMaxAvailableBalance()
+	*reply = client.MaxTrackerBalanceReply{MaxBalance: s.trackerStore.GetMaxAvailableBalance()}
 
 	return nil
 }

--- a/service/btc/query.go
+++ b/service/btc/query.go
@@ -23,3 +23,10 @@ func (s *Service) GetTracker(args client.BTCGetTrackerRequest, reply *client.BTC
 
 	return nil
 }
+
+func (s *Service) GetMaxTrackerBalance(args client.EmptyRequest, reply *client.MaxTrackerBalanceReply) error {
+
+	reply.MaxBalance = s.trackerStore.GetMaxAvailableBalance()
+
+	return nil
+}


### PR DESCRIPTION
1. taking multiple inputs for btc lock
2. added validation to make sure wrong inputs or transactions are not sent
3. estimating fees based on txn inputs/ outputs and standard public key/ signature sizes
4. returning money if btc lock fails

