### PR TITLE
OLP-639: Reorganized Auth configuration fields.

### DIFF
--- a/config/server.go
+++ b/config/server.go
@@ -188,11 +188,16 @@ type NodeConfig struct {
 	//rpc package
 	Services []string `toml:"services" desc:"List of services used by the current Node. Possible valued [broadcast, node, owner, query, tx]"`
 
+	Auth Authorisation `toml:"Auth" desc:"the OwnerCredentials and RPCPrivateKey should be configured together"`
+}
+
+type Authorisation struct {
 	//owner's password
-	OwnerCredentials []string `toml:"owner_credentials" desc:"Username and Password required to access owner services. Format [\"Username:Password\", \"Username:Password\"...]"`
+	OwnerCredentials []string `toml:"owner_credentials" desc:"Username and Password required to access owner services. Format [\"Username:Password\", \"Username:Password\"...]. 
+								if OwnerCredential not configured, anyone can create a public access token with a restful call at /token using the RPCPrivateKey"`
 
 	//Private Key for RPC Authentication
-	RPCPrivateKey string `toml:"rpc_private_key" desc:"(ED25519 key) This private key will be used to generate a token for authentication through RPC Port."`
+	RPCPrivateKey string `toml:"rpc_private_key" desc:"(ED25519 key) This private key will be used to generate a token for authentication through RPC Port; if not configured, anyone can access the SDK rpc port without authentication"`
 }
 
 func DefaultNodeConfig() *NodeConfig {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -90,7 +90,7 @@ func (r rpcAuthHandler) ServeHTTP(respW http.ResponseWriter, req *http.Request) 
 }
 
 func (r *rpcAuthHandler) Authorized(respW http.ResponseWriter, req *http.Request) bool {
-	if r.cfg != nil && r.cfg.Node.RPCPrivateKey != "" {
+	if r.cfg != nil && r.cfg.Node.Auth.RPCPrivateKey != "" {
 		respErr := ""
 		defer func() {
 			if respErr != "" {
@@ -111,7 +111,7 @@ func (r *rpcAuthHandler) Authorized(respW http.ResponseWriter, req *http.Request
 
 		var keyData []byte
 		//Get Private Key for signature verification.
-		keyData, err := base64.StdEncoding.DecodeString(r.cfg.Node.RPCPrivateKey)
+		keyData, err := base64.StdEncoding.DecodeString(r.cfg.Node.Auth.RPCPrivateKey)
 		if err != nil {
 			respErr = err.Error()
 			return false

--- a/scripts/rpcAuth/setup.py
+++ b/scripts/rpcAuth/setup.py
@@ -10,17 +10,18 @@ def setup_config(usr, privKey):
     Configuration = toml.load(conf)
 
     node_conf = Configuration['node']
+    auth_conf = node_conf['Auth']
 
     if usr:
-        node_conf['owner_credentials'] = ['username:password']
+        auth_conf['owner_credentials'] = ['username:password']
     else:
-        node_conf['owner_credentials'] = None
+        auth_conf['owner_credentials'] = None
 
     if privKey:
-        node_conf['rpc_private_key'] = \
+        auth_conf['rpc_private_key'] = \
             'pSKuldvwewRtuUcItfNhCgFy+RTscEnUejF2YRtnqvl98z17rUJLebNRvVwGSO0v3PFGhfng/CvUSru+qYD5Dw=='
     else:
-        node_conf['rpc_private_key'] = ""
+        auth_conf['rpc_private_key'] = ""
 
     f = open(conf, 'w')
     toml.dump(Configuration, f)

--- a/service/restful.go
+++ b/service/restful.go
@@ -103,8 +103,8 @@ func (rs RestfulService) GetToken() http.HandlerFunc {
 
 		rs.ctx.Logger.Error("Validating Username and Password")
 		//Validate Username and Password from request
-		if rs.ctx.Cfg.Node.OwnerCredentials != nil {
-			userList := rs.ctx.Cfg.Node.OwnerCredentials
+		if rs.ctx.Cfg.Node.Auth.OwnerCredentials != nil {
+			userList := rs.ctx.Cfg.Node.Auth.OwnerCredentials
 
 			for index, value := range userList {
 				//parse value into a pair
@@ -120,14 +120,14 @@ func (rs RestfulService) GetToken() http.HandlerFunc {
 			}
 		}
 
-		if rs.ctx.Cfg.Node.RPCPrivateKey != "" {
+		if rs.ctx.Cfg.Node.Auth.RPCPrivateKey != "" {
 
 			//Hash clientID given in the request and create an encoded token based on the hash
 			h.Write([]byte(clientReq.ClientID))
 			data := h.Sum(nil)[:20]
 
 			//Get Private Key for signature.
-			keyData, err := base64.StdEncoding.DecodeString(rs.ctx.Cfg.Node.RPCPrivateKey)
+			keyData, err := base64.StdEncoding.DecodeString(rs.ctx.Cfg.Node.Auth.RPCPrivateKey)
 			if err != nil {
 				rs.ctx.Logger.Error("Error decoding rpc private key", err)
 				clientResp.Message = err.Error()


### PR DESCRIPTION
Not an issue, works as designed. Grouped the authentication fields in the config together under one section. 