### PR TITLE
OLP-712 rpc call returning all tx types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ alltest: install
 	python scripts/ons/create_delete_subdomain.py
 	python scripts/ons/renew_domain.py
 	python scripts/reward/withdraw.py
+	python scripts/txTypes/listTxTypes.py
 	@./scripts/stopDev
 
 

--- a/action/base.go
+++ b/action/base.go
@@ -36,6 +36,12 @@ type Signature struct {
 	Signed []byte
 }
 
+type TxTypeDescribe struct{
+	TxTypeNum       Type
+	TxTypeString string
+
+}
+
 func (s Signature) Verify(msg []byte) bool {
 	handler, err := s.Signer.GetHandler()
 	if err != nil {

--- a/action/init.go
+++ b/action/init.go
@@ -39,6 +39,12 @@ const (
 	ETH_REDEEM               Type = 0x93
 	ERC20_LOCK               Type = 0x94
 	ERC20_REDEEM             Type = 0x95
+
+	//EOF here Only used as a marker to mark the end of Type list
+	//So that the query for Types can return all Types dynamically
+	//, when there is a change made in Type list
+	//This value should be manually set as the largest among the list
+	EOF			Type = 0xFF
 )
 
 var logger *log.Logger

--- a/client/request_types.go
+++ b/client/request_types.go
@@ -263,3 +263,8 @@ type MaxTrackerBalanceReply struct {
 type FeeOptionsReply struct {
 	FeeOption fees.FeeOption `json:"feeOption"`
 }
+
+type ListTxTypesRequest struct{}
+type ListTxTypesReply struct{
+	TxTypes []action.TxTypeDescribe `json:"txTypes"`
+}

--- a/scripts/txTypes/listTxTypes.py
+++ b/scripts/txTypes/listTxTypes.py
@@ -1,0 +1,32 @@
+import requests
+import json
+
+class bcolors:
+    WARNING = '\033[93m'
+    ENDC = '\033[0m'
+
+url = "http://127.0.0.1:26602/jsonrpc"
+headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+def rpc_call(method, params):
+    payload = {
+        "method": method,
+        "params": params,
+        "id": 123,
+        "jsonrpc": "2.0"
+    }
+
+    response = requests.request("POST", url, data=json.dumps(payload), headers=headers)
+
+    if response.status_code != 200:
+        return ""
+
+    resp = json.loads(response.text)
+    return resp
+
+print bcolors.WARNING + "*** List Tx Types ***" + bcolors.ENDC
+resp = rpc_call('query.ListTxTypes', {})
+print resp

--- a/service/map.go
+++ b/service/map.go
@@ -43,6 +43,9 @@ type Context struct {
 	Router   action.Router
 	Services client.ExtServiceContext
 	Logger   *log.Logger
+
+	TxTypes  *[]action.TxTypeDescribe
+
 }
 
 // Map of services, keyed by the name/prefix of the service
@@ -54,7 +57,7 @@ func NewMap(ctx *Context) (Map, error) {
 		broadcast.Name(): broadcast.NewService(ctx.Services, ctx.Router, ctx.Currencies, ctx.FeePool, ctx.Domains, ctx.Logger, ctx.Trackers),
 		nodesvc.Name():   nodesvc.NewService(ctx.NodeContext, &ctx.Cfg, ctx.Logger),
 		owner.Name():     owner.NewService(ctx.Accounts, ctx.Logger),
-		query.Name():     query.NewService(ctx.Services, ctx.Balances, ctx.Currencies, ctx.ValidatorSet, ctx.Domains, ctx.FeePool, ctx.Logger),
+		query.Name():     query.NewService(ctx.Services, ctx.Balances, ctx.Currencies, ctx.ValidatorSet, ctx.Domains, ctx.FeePool, ctx.Logger, ctx.TxTypes),
 		tx.Name():        tx.NewService(ctx.Balances, ctx.Router, ctx.Accounts, ctx.FeePool.GetOpt(), ctx.NodeContext, ctx.Logger),
 		btc.Name():       btc.NewService(ctx.Balances, ctx.Accounts, ctx.NodeContext, ctx.ValidatorSet, ctx.Trackers, ctx.Logger),
 		ethereum.Name():  ethereum.NewService(ctx.Cfg.EthChainDriver, ctx.Router, ctx.Accounts, ctx.NodeContext, ctx.ValidatorSet, ctx.EthTrackers, ctx.Logger),

--- a/service/query/service.go
+++ b/service/query/service.go
@@ -124,7 +124,8 @@ func (svc *Service) FeeOptions(_ struct{}, reply *client.FeeOptionsReply) error 
 func (svc *Service) ListTxTypes(_ client.ListTxTypesRequest, reply *client.ListTxTypesReply) error {
 	var txTypes []action.TxTypeDescribe
 	//find all const types that less than EOF marker
-	//and not "UNKNOWN"
+	//and not "UNKNOWN"(this also prevents the potential future const that not be the type: "Type"
+	//from showing up)
 	for i := 0; i < int(action.EOF); i++{
 		if strings.Compare(action.Type(i).String(), "UNKNOWN") != 0 {
 			txTypeDescribe := action.TxTypeDescribe{


### PR DESCRIPTION
1. define a struct to store tx type number and literal name in `action/base.go`
2. register a service in 
   1. Context struct and NewMap() func in `service/map.go` with the slice of the struct in previous step
   2. Service struct and NewService() func in `service/query/service.go`
3. to avoid hard copying the consts, add an useless Type `EOF` at the end of the const Type listed in `action/init.go` with a manually set number bigger than any Types. And when fetching these consts, I use a loop to fetch anything less than EOF and with a literal not same to “UNKNOWN”.
4. implement this service in `service/query/service.go`
5. add TxTypesRequest and TxTypesReply struct in `client/request_types.go`
6. create `scripts/txTypes/listTxTypes.py` to test this service
7. add `python scripts/listTxTypes.py` into makefile's `alltest` section to include this in alltest


rpc call result(after additional formatting):
```
{u'jsonrpc': u'2.0', u'id': 123, u'result': {u'txTypes': [
            {u'TxTypeString': u'SEND', u'TxTypeNum': 1
            },
            {u'TxTypeString': u'APPLY_VALIDATOR', u'TxTypeNum': 17
            },
            {u'TxTypeString': u'WITHDRAW', u'TxTypeNum': 18
            },
            {u'TxTypeString': u'DOMAIN_CREATE', u'TxTypeNum': 33
            },
            {u'TxTypeString': u'DOMAIN_UPDATE', u'TxTypeNum': 34
            },
            {u'TxTypeString': u'DOMAIN_SELL', u'TxTypeNum': 35
            },
            {u'TxTypeString': u'DOMAIN_PURCHASE', u'TxTypeNum': 36
            },
            {u'TxTypeString': u'DOMAIN_SEND', u'TxTypeNum': 37
            },
            {u'TxTypeString': u'DOMAIN_DELETE_SUB', u'TxTypeNum': 38
            },
            {u'TxTypeString': u'DOMAIN_RENEW', u'TxTypeNum': 39
            },
            {u'TxTypeString': u'BTC_LOCK', u'TxTypeNum': 129
            },
            {u'TxTypeString': u'BTC_ADD_SIGNATURE', u'TxTypeNum': 130
            },
            {u'TxTypeString': u'BTC_BROADCAST_SUCCESS', u'TxTypeNum': 131
            },
            {u'TxTypeString': u'BTC_REPORT_FINALITY_MINT', u'TxTypeNum': 132
            },
            {u'TxTypeString': u'BTC_EXT_MINT', u'TxTypeNum': 133
            },
            {u'TxTypeString': u'BTC_REDEEM', u'TxTypeNum': 134
            },
            {u'TxTypeString': u'BTC_FAILED_BROADCAST_RESET', u'TxTypeNum': 135
            },
            {u'TxTypeString': u'ETH_LOCK', u'TxTypeNum': 145
            },
            {u'TxTypeString': u'ETH_REPORT_FINALITY_MINT', u'TxTypeNum': 146
            },
            {u'TxTypeString': u'ETH_REDEEM', u'TxTypeNum': 147
            },
            {u'TxTypeString': u'ERC20_LOCK', u'TxTypeNum': 148
            },
            {u'TxTypeString': u'ERC20_REDEEM', u'TxTypeNum': 149
            }
        ]
    }
}
```