### PR TITLE
OLP-798 polish the test file

### DIFF
--- a/app/context.go
+++ b/app/context.go
@@ -83,7 +83,7 @@ func newContext(logWriter io.Writer, cfg config.Server, nodeCtx *node.Context) (
 	}
 	ctx.db = db
 	ctx.chainstate = storage.NewChainState("chainstate", db)
-	ctx.chainstate.SetupRotation(ctx.cfg.Node.ChainStateRotation.Recent, ctx.cfg.Node.ChainStateRotation.Every, ctx.cfg.Node.ChainStateRotation.Cycles)
+	ctx.chainstate.SetupRotation(ctx.cfg.Node.ChainStateRotation)
 	ctx.deliver = storage.NewState(ctx.chainstate)
 	ctx.check = storage.NewState(ctx.chainstate)
 

--- a/app/context.go
+++ b/app/context.go
@@ -83,7 +83,10 @@ func newContext(logWriter io.Writer, cfg config.Server, nodeCtx *node.Context) (
 	}
 	ctx.db = db
 	ctx.chainstate = storage.NewChainState("chainstate", db)
-	ctx.chainstate.SetupRotation(ctx.cfg.Node.ChainStateRotation)
+	errRotation := ctx.chainstate.SetupRotation(ctx.cfg.Node.ChainStateRotation)
+	if errRotation != nil {
+		return ctx, errors.Wrap(errRotation, "error in loading chain state rotation config")
+	}
 	ctx.deliver = storage.NewState(ctx.chainstate)
 	ctx.check = storage.NewState(ctx.chainstate)
 

--- a/storage/chainstate.go
+++ b/storage/chainstate.go
@@ -183,7 +183,7 @@ func (state *ChainState) Commit() ([]byte, int64) {
 				log.Error("Failed to delete old version of chainstate", "err:", err, "version:", release)
 			}
 		}
-		if state.chainStateRotation.cycles != 0 && release%state.chainStateRotation.every == 0 {
+		if state.chainStateRotation.cycles != 0 && state.chainStateRotation.every != 0 && release%state.chainStateRotation.every == 0 {
 			release = release - state.chainStateRotation.cycles*state.chainStateRotation.every
 			err := state.Delivered.DeleteVersion(release)
 			if err != nil {

--- a/storage/chainstate.go
+++ b/storage/chainstate.go
@@ -85,11 +85,18 @@ func NewChainState(name string, db tmdb.DB) *ChainState {
 // "recent" : latest number of version to persist
 // "every"  : every X number of version to persist
 // "cycles" : number of latest every version to persist
-func (state *ChainState) SetupRotation(chainStateRotationCfg config.ChainStateRotationCfg) {
+func (state *ChainState) SetupRotation(chainStateRotationCfg config.ChainStateRotationCfg) error {
 
+	isValid := chainStateRotationCfg.Recent >= 0 && chainStateRotationCfg.Every >= 0 && chainStateRotationCfg.Cycles >= 0
+	if isValid != true {
+		err := errors.New("found negative value in chain state rotation config")
+		return err
+	}
 	state.ChainStateRotation.recent = chainStateRotationCfg.Recent
 	state.ChainStateRotation.every = chainStateRotationCfg.Every
 	state.ChainStateRotation.cycles = chainStateRotationCfg.Cycles
+	return nil
+
 }
 
 // Do this only for the Delivery side

--- a/storage/chainstate.go
+++ b/storage/chainstate.go
@@ -22,6 +22,7 @@ package storage
 
 import (
 	"encoding/hex"
+	"github.com/Oneledger/protocol/config"
 	"strconv"
 	"sync"
 
@@ -43,12 +44,12 @@ type ChainState struct {
 	Hash        []byte
 	TreeHeight  int8
 
-	chainStateRotation chainStateRotationCfg
+	ChainStateRotation ChainStateRotationSetting
 
 	sync.RWMutex
 }
 
-type chainStateRotationCfg struct {
+type ChainStateRotationSetting struct {
 	//persistent data config
 
 	// "recent" : latest number of version to persist
@@ -84,13 +85,11 @@ func NewChainState(name string, db tmdb.DB) *ChainState {
 // "recent" : latest number of version to persist
 // "every"  : every X number of version to persist
 // "cycles" : number of latest every version to persist
-func (state *ChainState) SetupRotation(recent, every, cycles int64) {
-	//state.recent = recent
-	//state.every = every
-	//state.cycles = cycles
-	state.chainStateRotation.recent = recent
-	state.chainStateRotation.every = every
-	state.chainStateRotation.cycles = cycles
+func (state *ChainState) SetupRotation(chainStateRotationCfg config.ChainStateRotationCfg) {
+
+	state.ChainStateRotation.recent = chainStateRotationCfg.Recent
+	state.ChainStateRotation.every = chainStateRotationCfg.Every
+	state.ChainStateRotation.cycles = chainStateRotationCfg.Cycles
 }
 
 // Do this only for the Delivery side
@@ -174,17 +173,17 @@ func (state *ChainState) Commit() ([]byte, int64) {
 	state.LastVersion, state.Version = state.Version, version
 	state.LastHash, state.Hash = state.Hash, hash
 
-	release := state.LastVersion - state.chainStateRotation.recent
+	release := state.LastVersion - state.ChainStateRotation.recent
 
 	if release > 0 {
-		if state.chainStateRotation.every == 0 || release%state.chainStateRotation.every != 0 {
+		if state.ChainStateRotation.every == 0 || release%state.ChainStateRotation.every != 0 {
 			err := state.Delivered.DeleteVersion(release)
 			if err != nil {
 				log.Error("Failed to delete old version of chainstate", "err:", err, "version:", release)
 			}
 		}
-		if state.chainStateRotation.cycles != 0 && state.chainStateRotation.every != 0 && release%state.chainStateRotation.every == 0 {
-			release = release - state.chainStateRotation.cycles*state.chainStateRotation.every
+		if state.ChainStateRotation.cycles != 0 && state.ChainStateRotation.every != 0 && release%state.ChainStateRotation.every == 0 {
+			release = release - state.ChainStateRotation.cycles*state.ChainStateRotation.every
 			err := state.Delivered.DeleteVersion(release)
 			if err != nil {
 				log.Error("Failed to delete old version of chainstate", "err", err, "version:", release)

--- a/storage/chainstate_test.go
+++ b/storage/chainstate_test.go
@@ -131,11 +131,15 @@ func TestChainState_Rotation(t *testing.T) {
 		Cycles : int64(10),
 	}
 
-	//generate multiple versions
+
 	state := NewChainState("RotationTest", cacheDB)
-	state.SetupRotation(rotation)
+	err := state.SetupRotation(rotation)
+	if err != nil {
+		t.Errorf("error in loading chain state rotation config")
+		return
+	}
 
-
+	//generate multiple versions
 	//version start from 1
 	for i := 1; i <= testRound; i++ {
 

--- a/storage/chainstate_test.go
+++ b/storage/chainstate_test.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"bytes"
+	"github.com/Oneledger/protocol/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/db"
 	"math"
@@ -124,12 +125,15 @@ func TestChainState_Rotation(t *testing.T) {
 	calculatedRound := testRound - 1
 
 	//set up recent, every, cycles
-	recent := int64(10)
-	every := int64(100)
-	cycles := int64(10)
+	rotation := config.ChainStateRotationCfg{
+		Recent : int64(10),
+		Every : int64(100),
+		Cycles : int64(10),
+	}
+
 	//generate multiple versions
 	state := NewChainState("RotationTest", cacheDB)
-	state.SetupRotation(recent, every, cycles)
+	state.SetupRotation(rotation)
 
 
 	//version start from 1
@@ -158,6 +162,9 @@ func TestChainState_Rotation(t *testing.T) {
 	}
 
 	var correct int64
+	recent := rotation.Recent
+	every := rotation.Every
+	cycles := rotation.Cycles
 
 	// first figure out how many 'every' is reached
 	// here reachedEvery only consider the ones outside 'recent'

--- a/storage/chainstate_test.go
+++ b/storage/chainstate_test.go
@@ -16,11 +16,11 @@ package storage
 
 import (
 	"bytes"
-	"strconv"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/db"
+	"math"
+	"strconv"
+	"testing"
 )
 
 var cacheDB db.DB
@@ -118,12 +118,22 @@ func TestChainState_Commit(t *testing.T) {
 }
 
 func TestChainState_Rotation(t *testing.T) {
+	//set up test round
+	testRound := 10000
+	//the last round is special
+	calculatedRound := testRound - 1
+
+	//set up recent, every, cycles
+	recent := int64(10)
+	every := int64(100)
+	cycles := int64(10)
 	//generate multiple versions
 	state := NewChainState("RotationTest", cacheDB)
-	state.SetupRotation(10, 100, 10)
+	state.SetupRotation(recent, every, cycles)
+
 
 	//version start from 1
-	for i := 1; i < 10000; i++ {
+	for i := 1; i <= testRound; i++ {
 
 		key := "Hello " + strconv.Itoa(i)
 		value := "Value " + strconv.Itoa(i)
@@ -135,16 +145,51 @@ func TestChainState_Rotation(t *testing.T) {
 		version := state.Delivered.Version()
 		index, result := state.Delivered.GetVersioned(StoreKey(key), version)
 		log.Debug("Commited Fetched", "index", index, "version", version, "result", string(result))
-
-		//assert.Equal(t, []byte(value), result, "These should be equal")
-
 	}
 
-	for i := 1; i < 10000; i++ {
+	//looking for each version
+	counter := int64(0)
+	for i := 1; i <= testRound; i++ {
 		if state.Delivered.VersionExists(int64(i)) {
 			log.Debug("remaining version ", i)
+			counter++
 		}
 
 	}
+
+	var correct int64
+
+	// first figure out how many 'every' is reached
+	// here reachedEvery only consider the ones outside 'recent'
+	var reachedEvery int64
+	if every != 0 {
+		if cycles != 0{
+			if (int64(testRound) - recent) % every == 0 { //'every' overlaps with the oldest in recent
+				reachedEvery = int64(math.Min(float64((int64(testRound) - recent)/every - 1), float64(cycles)))
+			} else {
+				reachedEvery = int64(math.Min(float64((int64(testRound) - recent) / every), float64(cycles)))
+			}
+		} else {
+			if (int64(testRound) - recent) % every == 0 { //'every' overlaps with the oldest in recent
+				reachedEvery = (int64(testRound) - recent)/every - 1
+			} else {
+				reachedEvery = (int64(testRound) - recent)/every
+			}
+		}
+
+	} else {
+		reachedEvery = 0
+	}
+
+
+	if int64(calculatedRound) <= recent {
+		correct = int64(calculatedRound)
+	} else { // if 'every' and last round overlaps
+		correct = recent + reachedEvery
+	}
+
+	correct += 1// add the last round
+
+	assert.Equal(t, correct, counter, "These should be equal")
 
 }


### PR DESCRIPTION
1. made some changes to the test file to get correct dynamic result based on test parameters
2. resolved a bug in rotation calculation that `every` could be zero, and cannot be divided when calculate the remainder.

follow up changes:
- wrap elements into struct in storage/chainstate.go:SetupRotation(...)
- change struct type name to make a better fit.(the one in context is called ChainStateRotationCfg, the one in state is called ChainStateRotationSetting)
- capture error and early exit when find negative values in `recent`, `every`, `cycles`

Tested error message when run olfullnode in goland:
```
2020/04/07 23:48:15 listen to: [::]:65390
I[2020-04-07T23:48:15-04:00] storage: Reinitialized From Database version 0 tree_height 0 hash 
Error: failed to create new app: failed to create new app context: error in loading chain state rotation config: found negative value in chain state rotation config

```
