### PR TITLE
minor adjustment: change field name in json from "txTypes" to "txType"

### DIFF
--- a/client/request_types.go
+++ b/client/request_types.go
@@ -266,5 +266,5 @@ type FeeOptionsReply struct {
 
 type ListTxTypesRequest struct{}
 type ListTxTypesReply struct{
-	TxTypes []action.TxTypeDescribe `json:"txTypes"`
+	TxTypes []action.TxTypeDescribe `json:"txType"`
 }


### PR DESCRIPTION
related to OLP-712 and OLP-713
To be consistent with SDK side, change a field name in RPC json response : “txTypes” to “txType”