### PR TITLE
OLP-797: Create ethereum witness store

### DIFF
--- a/action/context.go
+++ b/action/context.go
@@ -26,6 +26,7 @@ type Context struct {
 	Currencies      *balance.CurrencySet
 	FeeOpt          *fees.FeeOption
 	Validators      *identity.ValidatorStore
+	Witnesses       *identity.EthWitnessStore
 	BTCTrackers     *bitcoin.TrackerStore
 	ETHTrackers     *ethereum.TrackerStore
 	Logger          *log.Logger
@@ -36,10 +37,10 @@ type Context struct {
 func NewContext(r Router, header *abci.Header, state *storage.State,
 	wallet accounts.Wallet, balances *balance.Store,
 	currencies *balance.CurrencySet, feePool *fees.Store,
-	validators *identity.ValidatorStore, domains *ons.DomainStore,
-	btcTrackers *bitcoin.TrackerStore, ethTrackers *ethereum.TrackerStore,
-	jobStore *jobs.JobStore, lockScriptStore *bitcoin.LockScriptStore,
-	logger *log.Logger) *Context {
+	validators *identity.ValidatorStore, witnesses *identity.EthWitnessStore,
+	domains *ons.DomainStore, btcTrackers *bitcoin.TrackerStore,
+	ethTrackers *ethereum.TrackerStore, jobStore *jobs.JobStore,
+	lockScriptStore *bitcoin.LockScriptStore, logger *log.Logger) *Context {
 
 	return &Context{
 		Router:          r,
@@ -51,6 +52,7 @@ func NewContext(r Router, header *abci.Header, state *storage.State,
 		FeePool:         feePool,
 		Currencies:      currencies,
 		Validators:      validators,
+		Witnesses:       witnesses,
 		BTCTrackers:     btcTrackers,
 		ETHTrackers:     ethTrackers,
 		Logger:          logger,

--- a/action/context.go
+++ b/action/context.go
@@ -26,7 +26,7 @@ type Context struct {
 	Currencies      *balance.CurrencySet
 	FeeOpt          *fees.FeeOption
 	Validators      *identity.ValidatorStore
-	Witnesses       *identity.EthWitnessStore
+	Witnesses       *identity.WitnessStore
 	BTCTrackers     *bitcoin.TrackerStore
 	ETHTrackers     *ethereum.TrackerStore
 	Logger          *log.Logger
@@ -37,7 +37,7 @@ type Context struct {
 func NewContext(r Router, header *abci.Header, state *storage.State,
 	wallet accounts.Wallet, balances *balance.Store,
 	currencies *balance.CurrencySet, feePool *fees.Store,
-	validators *identity.ValidatorStore, witnesses *identity.EthWitnessStore,
+	validators *identity.ValidatorStore, witnesses *identity.WitnessStore,
 	domains *ons.DomainStore, btcTrackers *bitcoin.TrackerStore,
 	ethTrackers *ethereum.TrackerStore, jobStore *jobs.JobStore,
 	lockScriptStore *bitcoin.LockScriptStore, logger *log.Logger) *Context {

--- a/action/eth/ext_ERC20Lock.go
+++ b/action/eth/ext_ERC20Lock.go
@@ -153,9 +153,9 @@ func runERC20Lock(ctx *action.Context, tx action.RawTx) (bool, action.Response) 
 		}
 	}
 
-	validatorList, err := ctx.Validators.GetValidatorsAddress()
+	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
 	if err != nil {
-		ctx.Logger.Error("err in getting validator address", err)
+		ctx.Logger.Error("err in getting witness address", err)
 		return false, action.Response{Log: "error in getting validator addresses" + err.Error()}
 	}
 
@@ -190,7 +190,7 @@ func runERC20Lock(ctx *action.Context, tx action.RawTx) (bool, action.Response) 
 		erc20lock.Locker,
 		erc20lock.ETHTxn,
 		ethcommon.BytesToHash(erc20lock.ETHTxn),
-		validatorList,
+		witnesses,
 	)
 
 	err = ctx.ETHTrackers.WithPrefixType(ethereum.PrefixOngoing).Set(tracker)

--- a/action/eth/ext_ERC20Lock.go
+++ b/action/eth/ext_ERC20Lock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Oneledger/protocol/action"
 	ethchaindriver "github.com/Oneledger/protocol/chains/ethereum"
+	"github.com/Oneledger/protocol/data/chain"
 	"github.com/Oneledger/protocol/data/ethereum"
 )
 
@@ -153,7 +154,7 @@ func runERC20Lock(ctx *action.Context, tx action.RawTx) (bool, action.Response) 
 		}
 	}
 
-	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
+	witnesses, err := ctx.Witnesses.GetWitnessAddresses(chain.ETHEREUM)
 	if err != nil {
 		ctx.Logger.Error("err in getting witness address", err)
 		return false, action.Response{Log: "error in getting validator addresses" + err.Error()}

--- a/action/eth/ext_ERC20redeem.go
+++ b/action/eth/ext_ERC20redeem.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Oneledger/protocol/action"
 	"github.com/Oneledger/protocol/chains/ethereum"
 	"github.com/Oneledger/protocol/data/balance"
+	"github.com/Oneledger/protocol/data/chain"
 	trackerlib "github.com/Oneledger/protocol/data/ethereum"
 	"github.com/Oneledger/protocol/data/keys"
 )
@@ -154,7 +155,7 @@ func runERC20Reddem(ctx *action.Context, tx action.RawTx) (bool, action.Response
 		return false, action.Response{Log: action.ErrNotEnoughFund.Error()}
 	}
 
-	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
+	witnesses, err := ctx.Witnesses.GetWitnessAddresses(chain.ETHEREUM)
 	if err != nil {
 		return false, action.Response{Log: "error in getting validator addresses" + err.Error()}
 	}

--- a/action/eth/ext_ERC20redeem.go
+++ b/action/eth/ext_ERC20redeem.go
@@ -154,7 +154,7 @@ func runERC20Reddem(ctx *action.Context, tx action.RawTx) (bool, action.Response
 		return false, action.Response{Log: action.ErrNotEnoughFund.Error()}
 	}
 
-	validators, err := ctx.Validators.GetValidatorsAddress()
+	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
 	if err != nil {
 		return false, action.Response{Log: "error in getting validator addresses" + err.Error()}
 	}
@@ -170,7 +170,7 @@ func runERC20Reddem(ctx *action.Context, tx action.RawTx) (bool, action.Response
 		erc20redeem.Owner,
 		erc20redeem.ETHTxn,
 		name,
-		validators,
+		witnesses,
 	)
 
 	tracker.State = trackerlib.New

--- a/action/eth/ext_lock.go
+++ b/action/eth/ext_lock.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Oneledger/protocol/action"
 	ethchaindriver "github.com/Oneledger/protocol/chains/ethereum"
+	"github.com/Oneledger/protocol/data/chain"
 	"github.com/Oneledger/protocol/data/ethereum"
 )
 
@@ -173,7 +174,7 @@ func runLock(ctx *action.Context, lock *Lock) (bool, action.Response) {
 		}
 	}
 
-	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
+	witnesses, err := ctx.Witnesses.GetWitnessAddresses(chain.ETHEREUM)
 	if err != nil {
 
 		ctx.Logger.Error("err in getting validator address", err)

--- a/action/eth/ext_lock.go
+++ b/action/eth/ext_lock.go
@@ -173,7 +173,7 @@ func runLock(ctx *action.Context, lock *Lock) (bool, action.Response) {
 		}
 	}
 
-	val, err := ctx.Validators.GetValidatorsAddress()
+	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
 	if err != nil {
 
 		ctx.Logger.Error("err in getting validator address", err)
@@ -212,7 +212,7 @@ func runLock(ctx *action.Context, lock *Lock) (bool, action.Response) {
 		lock.Locker,
 		lock.ETHTxn,
 		name,
-		val,
+		witnesses,
 	)
 
 	tracker.State = ethereum.New

--- a/action/eth/ext_redeem.go
+++ b/action/eth/ext_redeem.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Oneledger/protocol/action"
 	"github.com/Oneledger/protocol/chains/ethereum"
 	"github.com/Oneledger/protocol/data/balance"
+	"github.com/Oneledger/protocol/data/chain"
 	trackerlib "github.com/Oneledger/protocol/data/ethereum"
 	"github.com/Oneledger/protocol/data/keys"
 )
@@ -141,7 +142,7 @@ func runRedeem(ctx *action.Context, tx action.RawTx) (bool, action.Response) {
 		return false, action.Response{Log: (errors.Wrap(action.ErrNotEnoughFund, err.Error())).Error()}
 	}
 
-	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
+	witnesses, err := ctx.Witnesses.GetWitnessAddresses(chain.ETHEREUM)
 	if err != nil {
 		return false, action.Response{Log: "error in getting validator addresses" + err.Error()}
 	}

--- a/action/eth/ext_redeem.go
+++ b/action/eth/ext_redeem.go
@@ -141,7 +141,7 @@ func runRedeem(ctx *action.Context, tx action.RawTx) (bool, action.Response) {
 		return false, action.Response{Log: (errors.Wrap(action.ErrNotEnoughFund, err.Error())).Error()}
 	}
 
-	validators, err := ctx.Validators.GetValidatorsAddress()
+	witnesses, err := ctx.Witnesses.GetETHWitnessAddresses()
 	if err != nil {
 		return false, action.Response{Log: "error in getting validator addresses" + err.Error()}
 	}
@@ -157,7 +157,7 @@ func runRedeem(ctx *action.Context, tx action.RawTx) (bool, action.Response) {
 		redeem.Owner,
 		redeem.ETHTxn,
 		name,
-		validators,
+		witnesses,
 	)
 
 	tracker.State = trackerlib.New

--- a/app/application.go
+++ b/app/application.go
@@ -2,9 +2,10 @@ package app
 
 import (
 	"fmt"
-	"github.com/Oneledger/protocol/data/ethereum"
 	"net/url"
 	"os"
+
+	"github.com/Oneledger/protocol/data/ethereum"
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/pkg/errors"
@@ -209,7 +210,7 @@ func (app *App) setupState(stateBytes []byte) error {
 			State:         tracker.State,
 			TrackerName:   tracker.TrackerName,
 			SignedETHTx:   tracker.SignedETHTx,
-			Validators:    tracker.Validators,
+			Witnesses:     tracker.Validators,
 			ProcessOwner:  tracker.ProcessOwner,
 			FinalityVotes: make([]ethereum.Vote, len(tracker.Validators)),
 			To:            tracker.To,

--- a/app/application.go
+++ b/app/application.go
@@ -363,6 +363,9 @@ func (app *App) Prepare() error {
 		return errors.Wrap(err, "failed to create new consensus.Node")
 	}
 
+	// Init witness store after genesis witnesses loaded in above NewNode
+	app.Context.witnesses.Init(chain.ETHEREUM, app.Context.node.ValidatorAddress())
+
 	return nil
 }
 

--- a/app/application.go
+++ b/app/application.go
@@ -342,6 +342,10 @@ func (app *App) Start() error {
 		app.logger.Error("Failed to create consensus.Node")
 		return errors.Wrap(err, "failed to create new consensus.Node")
 	}
+
+	// Init isWitness flag after genesis witnesses loaded in NewNode
+	app.Context.ethWitnesses.Init(app.Context.node.ValidatorAddress())
+
 	err = node.Start()
 	if err != nil {
 		app.logger.Error("Failed to start consensus.Node")

--- a/app/application.go
+++ b/app/application.go
@@ -210,9 +210,9 @@ func (app *App) setupState(stateBytes []byte) error {
 			State:         tracker.State,
 			TrackerName:   tracker.TrackerName,
 			SignedETHTx:   tracker.SignedETHTx,
-			Witnesses:     tracker.Validators,
+			Witnesses:     tracker.Witnesses,
 			ProcessOwner:  tracker.ProcessOwner,
-			FinalityVotes: make([]ethereum.Vote, len(tracker.Validators)),
+			FinalityVotes: make([]ethereum.Vote, len(tracker.Witnesses)),
 			To:            tracker.To,
 		}
 		switch tracker.State {

--- a/app/application.go
+++ b/app/application.go
@@ -171,6 +171,10 @@ func (app *App) setupState(stateBytes []byte) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to handle initial staking")
 		}
+		err = app.Context.ethWitnesses.WithState(app.Context.deliver).AddWitness(identity.Stake(stake))
+		if err != nil {
+			return errors.Wrap(err, "failed to add initial ethereum witness")
+		}
 	}
 
 	for _, domain := range initial.Domains {

--- a/app/context.go
+++ b/app/context.go
@@ -47,15 +47,15 @@ type context struct {
 	check      *storage.State
 	deliver    *storage.State
 
-	balances     *balance.Store
-	domains      *ons.DomainStore
-	validators   *identity.ValidatorStore  // Set of validators currently active
-	ethWitnesses *identity.EthWitnessStore // Set of ethereum witnesses currently active
-	feePool      *fees.Store
-	govern       *governance.Store
-	btcTrackers  *bitcoin.TrackerStore  // tracker for bitcoin balance UTXO
-	ethTrackers  *ethereum.TrackerStore // Tracker store for ongoing ethereum trackers
-	currencies   *balance.CurrencySet
+	balances    *balance.Store
+	domains     *ons.DomainStore
+	validators  *identity.ValidatorStore // Set of validators currently active
+	witnesses   *identity.WitnessStore   // Set of witnesses currently active
+	feePool     *fees.Store
+	govern      *governance.Store
+	btcTrackers *bitcoin.TrackerStore  // tracker for bitcoin balance UTXO
+	ethTrackers *ethereum.TrackerStore // Tracker store for ongoing ethereum trackers
+	currencies  *balance.CurrencySet
 
 	//storage which is not a chain state
 	accounts accounts.Wallet
@@ -92,7 +92,7 @@ func newContext(logWriter io.Writer, cfg config.Server, nodeCtx *node.Context) (
 	ctx.check = storage.NewState(ctx.chainstate)
 
 	ctx.validators = identity.NewValidatorStore("v", storage.NewState(ctx.chainstate))
-	ctx.ethWitnesses = identity.NewEthWitnessStore("etw", storage.NewState(ctx.chainstate))
+	ctx.witnesses = identity.NewWitnessStore("w", storage.NewState(ctx.chainstate))
 	ctx.balances = balance.NewStore("b", storage.NewState(ctx.chainstate))
 	ctx.domains = ons.NewDomainStore("d", storage.NewState(ctx.chainstate))
 	ctx.feePool = fees.NewStore("f", storage.NewState(ctx.chainstate))
@@ -140,7 +140,7 @@ func (ctx *context) Action(header *Header, state *storage.State) *action.Context
 		ctx.currencies,
 		ctx.feePool.WithState(state),
 		ctx.validators.WithState(state),
-		ctx.ethWitnesses.WithState(state),
+		ctx.witnesses.WithState(state),
 		ctx.domains.WithState(state),
 
 		ctx.btcTrackers.WithState(state),

--- a/app/context.go
+++ b/app/context.go
@@ -47,14 +47,15 @@ type context struct {
 	check      *storage.State
 	deliver    *storage.State
 
-	balances    *balance.Store
-	domains     *ons.DomainStore
-	validators  *identity.ValidatorStore // Set of validators currently active
-	feePool     *fees.Store
-	govern      *governance.Store
-	btcTrackers *bitcoin.TrackerStore  // tracker for bitcoin balance UTXO
-	ethTrackers *ethereum.TrackerStore // Tracker store for ongoing ethereum trackers
-	currencies  *balance.CurrencySet
+	balances     *balance.Store
+	domains      *ons.DomainStore
+	validators   *identity.ValidatorStore  // Set of validators currently active
+	ethWitnesses *identity.EthWitnessStore // Set of ethereum witnesses currently active
+	feePool      *fees.Store
+	govern       *governance.Store
+	btcTrackers  *bitcoin.TrackerStore  // tracker for bitcoin balance UTXO
+	ethTrackers  *ethereum.TrackerStore // Tracker store for ongoing ethereum trackers
+	currencies   *balance.CurrencySet
 
 	//storage which is not a chain state
 	accounts accounts.Wallet
@@ -91,6 +92,7 @@ func newContext(logWriter io.Writer, cfg config.Server, nodeCtx *node.Context) (
 	ctx.check = storage.NewState(ctx.chainstate)
 
 	ctx.validators = identity.NewValidatorStore("v", storage.NewState(ctx.chainstate))
+	ctx.ethWitnesses = identity.NewEthWitnessStore("etw", storage.NewState(ctx.chainstate))
 	ctx.balances = balance.NewStore("b", storage.NewState(ctx.chainstate))
 	ctx.domains = ons.NewDomainStore("d", storage.NewState(ctx.chainstate))
 	ctx.feePool = fees.NewStore("f", storage.NewState(ctx.chainstate))
@@ -138,6 +140,7 @@ func (ctx *context) Action(header *Header, state *storage.State) *action.Context
 		ctx.currencies,
 		ctx.feePool.WithState(state),
 		ctx.validators.WithState(state),
+		ctx.ethWitnesses.WithState(state),
 		ctx.domains.WithState(state),
 
 		ctx.btcTrackers.WithState(state),

--- a/app/controller.go
+++ b/app/controller.go
@@ -240,7 +240,7 @@ func (app *App) blockEnder() blockEnder {
 		}
 		ethTrackerlog := log.NewLoggerWithPrefix(app.Context.logWriter, "ethtracker").WithLevel(log.Level(app.Context.cfg.Node.LogLevel))
 		doTransitions(app.Context.jobStore, app.Context.btcTrackers.WithState(app.Context.deliver), app.Context.validators)
-		doEthTransitions(app.Context.jobStore, app.Context.ethTrackers, app.Context.node.ValidatorAddress(), ethTrackerlog, app.Context.validators, app.Context.deliver)
+		doEthTransitions(app.Context.jobStore, app.Context.ethTrackers, app.Context.node.ValidatorAddress(), ethTrackerlog, app.Context.ethWitnesses, app.Context.deliver)
 
 		app.logger.Detail("End Block: ", result, "height:", req.Height)
 
@@ -337,7 +337,7 @@ func doTransitions(js *jobs.JobStore, ts *bitcoin.TrackerStore, validators *iden
 	}
 }
 
-func doEthTransitions(js *jobs.JobStore, ts *ethereum.TrackerStore, myValAddr keys.Address, logger *log.Logger, validators *identity.ValidatorStore, deliver *storage.State) {
+func doEthTransitions(js *jobs.JobStore, ts *ethereum.TrackerStore, myValAddr keys.Address, logger *log.Logger, witnesses *identity.EthWitnessStore, deliver *storage.State) {
 	ts = ts.WithState(deliver)
 	tnames := make([]*ceth.TrackerName, 0, 20)
 	ts.WithPrefixType(ethereum.PrefixOngoing).Iterate(func(name *ceth.TrackerName, tracker *ethereum.Tracker) bool {
@@ -349,7 +349,7 @@ func doEthTransitions(js *jobs.JobStore, ts *ethereum.TrackerStore, myValAddr ke
 		deliver.BeginTxSession()
 		t, _ := ts.WithPrefixType(ethereum.PrefixOngoing).Get(*name)
 		state := t.State
-		ctx := ethereum.NewTrackerCtx(t, myValAddr, js.WithChain(chain.ETHEREUM), ts, validators, logger)
+		ctx := ethereum.NewTrackerCtx(t, myValAddr, js.WithChain(chain.ETHEREUM), ts, witnesses, logger)
 
 		if t.Type == ethereum.ProcessTypeLock || t.Type == ethereum.ProcessTypeLockERC {
 

--- a/app/controller.go
+++ b/app/controller.go
@@ -240,7 +240,7 @@ func (app *App) blockEnder() blockEnder {
 		}
 		ethTrackerlog := log.NewLoggerWithPrefix(app.Context.logWriter, "ethtracker").WithLevel(log.Level(app.Context.cfg.Node.LogLevel))
 		doTransitions(app.Context.jobStore, app.Context.btcTrackers.WithState(app.Context.deliver), app.Context.validators)
-		doEthTransitions(app.Context.jobStore, app.Context.ethTrackers, app.Context.node.ValidatorAddress(), ethTrackerlog, app.Context.ethWitnesses, app.Context.deliver)
+		doEthTransitions(app.Context.jobStore, app.Context.ethTrackers, app.Context.node.ValidatorAddress(), ethTrackerlog, app.Context.witnesses, app.Context.deliver)
 
 		app.logger.Detail("End Block: ", result, "height:", req.Height)
 
@@ -337,7 +337,7 @@ func doTransitions(js *jobs.JobStore, ts *bitcoin.TrackerStore, validators *iden
 	}
 }
 
-func doEthTransitions(js *jobs.JobStore, ts *ethereum.TrackerStore, myValAddr keys.Address, logger *log.Logger, witnesses *identity.EthWitnessStore, deliver *storage.State) {
+func doEthTransitions(js *jobs.JobStore, ts *ethereum.TrackerStore, myValAddr keys.Address, logger *log.Logger, witnesses *identity.WitnessStore, deliver *storage.State) {
 	ts = ts.WithState(deliver)
 	tnames := make([]*ceth.TrackerName, 0, 20)
 	ts.WithPrefixType(ethereum.PrefixOngoing).Iterate(func(name *ceth.TrackerName, tracker *ethereum.Tracker) bool {

--- a/cmd/olfullnode/save_state.go
+++ b/cmd/olfullnode/save_state.go
@@ -450,7 +450,7 @@ func DumpTrackerToFile(ts *ethereum.TrackerStore, writer io.Writer, fn func(writ
 			trackerState.ProcessOwner = tracker.ProcessOwner
 			trackerState.SignedETHTx = tracker.SignedETHTx
 			trackerState.TrackerName = tracker.TrackerName
-			trackerState.Validators = tracker.Witnesses
+			trackerState.Witnesses = tracker.Witnesses
 			trackerState.To = tracker.To
 
 			fn(writer, trackerState)

--- a/cmd/olfullnode/save_state.go
+++ b/cmd/olfullnode/save_state.go
@@ -4,6 +4,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/Oneledger/protocol/app"
 	olNode "github.com/Oneledger/protocol/app/node"
 	ethChain "github.com/Oneledger/protocol/chains/ethereum"
@@ -20,10 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/types"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 // ConsensusParams contains consensus critical parameters that determine the
@@ -449,7 +450,7 @@ func DumpTrackerToFile(ts *ethereum.TrackerStore, writer io.Writer, fn func(writ
 			trackerState.ProcessOwner = tracker.ProcessOwner
 			trackerState.SignedETHTx = tracker.SignedETHTx
 			trackerState.TrackerName = tracker.TrackerName
-			trackerState.Validators = tracker.Validators
+			trackerState.Validators = tracker.Witnesses
 			trackerState.To = tracker.To
 
 			fn(writer, trackerState)

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -69,7 +69,7 @@ type Tracker struct {
 	State         ethData.TrackerState `json:"state"`
 	TrackerName   ethchain.TrackerName `json:"trackerName"`
 	SignedETHTx   []byte               `json:"signedEthTx"`
-	Validators    []keys.Address       `json:"validators"`
+	Witnesses     []keys.Address       `json:"witnesses"`
 	ProcessOwner  keys.Address         `json:"processOwner"`
 	FinalityVotes []ethData.Vote       `json:"finalityVotes"`
 	To            keys.Address         `json:"to"`

--- a/data/ethereum/context.go
+++ b/data/ethereum/context.go
@@ -12,17 +12,17 @@ type TrackerCtx struct {
 	TrackerStore *TrackerStore
 	JobStore     *jobs.JobStore
 	CurrNodeAddr keys.Address
-	Validators   *identity.ValidatorStore
+	Witnesses    *identity.EthWitnessStore
 	Logger       *log.Logger
 }
 
-func NewTrackerCtx(t *Tracker, addr keys.Address, js *jobs.JobStore, ts *TrackerStore, vs *identity.ValidatorStore, log *log.Logger) *TrackerCtx {
+func NewTrackerCtx(t *Tracker, addr keys.Address, js *jobs.JobStore, ts *TrackerStore, ws *identity.EthWitnessStore, log *log.Logger) *TrackerCtx {
 	return &TrackerCtx{
 		Tracker:      t,
 		CurrNodeAddr: addr,
 		JobStore:     js,
 		TrackerStore: ts,
-		Validators:   vs,
+		Witnesses:    ws,
 		Logger:       log,
 	}
 }

--- a/data/ethereum/context.go
+++ b/data/ethereum/context.go
@@ -12,11 +12,11 @@ type TrackerCtx struct {
 	TrackerStore *TrackerStore
 	JobStore     *jobs.JobStore
 	CurrNodeAddr keys.Address
-	Witnesses    *identity.EthWitnessStore
+	Witnesses    *identity.WitnessStore
 	Logger       *log.Logger
 }
 
-func NewTrackerCtx(t *Tracker, addr keys.Address, js *jobs.JobStore, ts *TrackerStore, ws *identity.EthWitnessStore, log *log.Logger) *TrackerCtx {
+func NewTrackerCtx(t *Tracker, addr keys.Address, js *jobs.JobStore, ts *TrackerStore, ws *identity.WitnessStore, log *log.Logger) *TrackerCtx {
 	return &TrackerCtx{
 		Tracker:      t,
 		CurrNodeAddr: addr,

--- a/data/ethereum/tracker.go
+++ b/data/ethereum/tracker.go
@@ -20,14 +20,14 @@ type Tracker struct {
 	State         TrackerState
 	TrackerName   ethereum.TrackerName
 	SignedETHTx   []byte
-	Validators    []keys.Address
+	Witnesses     []keys.Address
 	ProcessOwner  keys.Address
 	FinalityVotes []Vote
 	To            keys.Address
 }
 
 //number of validator should be smaller than 64
-func NewTracker(typ ProcessType, owner keys.Address, signedEthTx []byte, name ethereum.TrackerName, validators []keys.Address) *Tracker {
+func NewTracker(typ ProcessType, owner keys.Address, signedEthTx []byte, name ethereum.TrackerName, witnesses []keys.Address) *Tracker {
 
 	return &Tracker{
 		Type:          typ,
@@ -35,14 +35,14 @@ func NewTracker(typ ProcessType, owner keys.Address, signedEthTx []byte, name et
 		TrackerName:   name,
 		ProcessOwner:  owner,
 		SignedETHTx:   signedEthTx,
-		Validators:    validators,
-		FinalityVotes: make([]Vote, len(validators)),
+		Witnesses:     witnesses,
+		FinalityVotes: make([]Vote, len(witnesses)),
 	}
 }
 
 func (t *Tracker) AddVote(addr keys.Address, index int64, vote bool) error {
 
-	if len(t.Validators) <= int(index) {
+	if len(t.Witnesses) <= int(index) {
 		return errTrackerInvalidVote
 	}
 
@@ -50,7 +50,7 @@ func (t *Tracker) AddVote(addr keys.Address, index int64, vote bool) error {
 	if voted {
 		return errTrackerInvalidVote
 	}
-	if t.Validators[index].Equal(addr) {
+	if t.Witnesses[index].Equal(addr) {
 		//		t.FinalityVotes = (t.FinalityVotes | (1 << index))
 		//		return nil
 
@@ -90,13 +90,13 @@ func (t *Tracker) GetVotes() (yes, no int) {
 
 func (t *Tracker) CheckIfVoted(node keys.Address) (index int64, voted bool) {
 	index = int64(-1)
-	for i, addr := range t.Validators {
+	for i, addr := range t.Witnesses {
 		if addr.Equal(node) {
 			index = int64(i)
 			break
 		}
 	}
-	//if index < int64(len(t.Validators)) && index >= 0 {
+	//if index < int64(len(t.Witnesses)) && index >= 0 {
 	//	var mybit uint64 = 1 << index
 	//	and := t.FinalityVotes & mybit
 	//	v = and == mybit
@@ -112,7 +112,7 @@ func (t *Tracker) CheckIfVoted(node keys.Address) (index int64, voted bool) {
 }
 
 func (t *Tracker) Finalized() bool {
-	l := len(t.Validators)
+	l := len(t.Witnesses)
 	num := (l * 2 / 3) + 1
 	//v := t.FinalityVotes
 	//cnt := 0
@@ -127,7 +127,7 @@ func (t *Tracker) Finalized() bool {
 }
 
 func (t *Tracker) Failed() bool {
-	l := len(t.Validators)
+	l := len(t.Witnesses)
 	num := (l * 2 / 3) + 1
 	//v := t.FinalityVotes
 	//cnt := 0

--- a/event/eth_lock_transitions.go
+++ b/event/eth_lock_transitions.go
@@ -89,7 +89,7 @@ func Broadcasting(ctx interface{}) error {
 	context.Tracker = tracker
 
 	//create broadcasting
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 
 		job := NewETHBroadcast((*tracker).TrackerName, ethereum.BusyBroadcasting)
 		err := context.JobStore.SaveJob(job)
@@ -118,7 +118,7 @@ func Finalizing(ctx interface{}) error {
 	}
 
 	context.Tracker = tracker
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		_, voted := tracker.CheckIfVoted(context.CurrNodeAddr)
 		if voted {
 			return nil
@@ -166,7 +166,7 @@ func Finalization(ctx interface{}) error {
 		return nil
 	}
 
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		//Check if current Node voted
 		_, voted := tracker.CheckIfVoted(context.CurrNodeAddr)
 
@@ -212,7 +212,7 @@ func Cleanup(ctx interface{}) error {
 	}
 
 	//Delete Broadcasting Job
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		bjob, err := context.JobStore.GetJob(tracker.GetJobID(ethereum.BusyBroadcasting))
 		if err != nil {
 			return errors.Wrap(err, "Failed to get Broadcasting Job")
@@ -256,7 +256,7 @@ func CleanupFailed(ctx interface{}) error {
 	}
 
 	//Delete Broadcasting Job It its there
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		bjob, err := context.JobStore.GetJob(tracker.GetJobID(ethereum.BusyBroadcasting))
 		if err == nil {
 			err = context.JobStore.DeleteJob(bjob)

--- a/event/eth_lock_transitions.go
+++ b/event/eth_lock_transitions.go
@@ -212,7 +212,7 @@ func Cleanup(ctx interface{}) error {
 	}
 
 	//Delete Jobs
-	if context.Validators.IsETHWitness() {
+	if context.Witnesses.IsETHWitness() {
 		for state := ethereum.BusyBroadcasting; state <= ethereum.Released; state++ {
 			job, err := context.JobStore.GetJob(tracker.GetJobID(state))
 			if err != nil {
@@ -249,7 +249,7 @@ func CleanupFailed(ctx interface{}) error {
 	}
 
 	//Delete Broadcasting Job It its there
-	if context.Validators.IsETHWitness() {
+	if context.Witnesses.IsETHWitness() {
 		for state := ethereum.BusyBroadcasting; state <= ethereum.Released; state++ {
 			job, err := context.JobStore.GetJob(tracker.GetJobID(state))
 			if err != nil {

--- a/event/eth_redeem_transitions.go
+++ b/event/eth_redeem_transitions.go
@@ -85,7 +85,7 @@ func Signing(ctx interface{}) error {
 		return errors.Wrap(err, string((*tracker).State))
 	}
 	tracker.State = ethereum.BusyBroadcasting
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 
 		job := NewETHSignRedeem(tracker.TrackerName, ethereum.BusyBroadcasting)
 		err := context.JobStore.SaveJob(job)
@@ -112,7 +112,7 @@ func VerifyRedeem(ctx interface{}) error {
 		return errors.Wrap(err, tracker.State.String())
 	}
 
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		bjob, err := context.JobStore.GetJob(tracker.GetJobID(ethereum.BusyBroadcasting))
 		if err != nil {
 			return errors.Wrap(err, "failed to get job")
@@ -160,7 +160,7 @@ func redeemCleanup(ctx interface{}) error {
 	}
 	tracker := context.Tracker
 	//delete the tracker related jobs
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		for state := ethereum.BusyBroadcasting; state <= ethereum.Released; state++ {
 			job, err := context.JobStore.GetJob(tracker.GetJobID(state))
 			if err != nil {
@@ -195,7 +195,7 @@ func redeemCleanupFailed(ctx interface{}) error {
 	}
 	tracker := context.Tracker
 	//delete the tracker related jobs
-	if context.Validators.IsValidator() {
+	if context.Witnesses.IsETHWitness() {
 		for state := ethereum.BusyBroadcasting; state <= ethereum.Failed; state++ {
 			job, err := context.JobStore.GetJob(tracker.GetJobID(state))
 			if err != nil {

--- a/event/eth_transitions_test.go
+++ b/event/eth_transitions_test.go
@@ -29,7 +29,7 @@ var (
 	chainState  storage.ChainState
 	ethTrackers ethereum.TrackerStore
 	jobStore    jobs.JobStore
-	witStore    identity.EthWitnessStore
+	witStore    identity.WitnessStore
 	logger      *log.Logger
 
 	testCases map[int]Case
@@ -58,7 +58,7 @@ func setup() {
 	chainState = *storage.NewChainState("chainstate", db)
 	ethTrackers = *ethereum.NewTrackerStore("etht", "ethfail", "ethsuccess", storage.NewState(&chainState))
 	jobStore = *jobs.NewJobStore(*config.DefaultServerConfig(), "test_dbpath")
-	witStore = *identity.NewEthWitnessStore("wit", storage.NewState(&chainState))
+	witStore = *identity.NewWitnessStore("wit", storage.NewState(&chainState))
 	logger = log.NewDefaultLogger(os.Stdout).WithPrefix("test")
 }
 

--- a/event/eth_transitions_test.go
+++ b/event/eth_transitions_test.go
@@ -2,6 +2,9 @@ package event
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/Oneledger/protocol/config"
 	"github.com/Oneledger/protocol/data/chain"
 	"github.com/Oneledger/protocol/data/ethereum"
@@ -12,8 +15,6 @@ import (
 	"github.com/Oneledger/protocol/utils/transition"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/magiconair/properties/assert"
-	"strconv"
-	"testing"
 )
 
 var (

--- a/identity/eth_witness.go
+++ b/identity/eth_witness.go
@@ -1,18 +1,20 @@
 package identity
 
 import (
+	"github.com/Oneledger/protocol/data/chain"
 	"github.com/Oneledger/protocol/data/keys"
 	"github.com/Oneledger/protocol/serialize"
 )
 
-type EthWitness struct {
+type Witness struct {
 	Address     keys.Address   `json:"address"`
 	PubKey      keys.PublicKey `json:"pubKey"`
 	ECDSAPubKey keys.PublicKey `json:"ecdsaPubkey"`
 	Name        string         `json:"name"`
+	Chain       chain.Type     `json:"chain"`
 }
 
-func (w *EthWitness) Bytes() []byte {
+func (w *Witness) Bytes() []byte {
 	value, err := serialize.GetSerializer(serialize.PERSISTENT).Serialize(w)
 	if err != nil {
 		logger.Error("ethereum witness not serializable", err)
@@ -21,7 +23,7 @@ func (w *EthWitness) Bytes() []byte {
 	return value
 }
 
-func (w *EthWitness) FromBytes(msg []byte) (*EthWitness, error) {
+func (w *Witness) FromBytes(msg []byte) (*Witness, error) {
 	err := serialize.GetSerializer(serialize.PERSISTENT).Deserialize(msg, w)
 	if err != nil {
 		logger.Error("failed to deserialize ethereum witness from bytes", err)

--- a/identity/eth_witness.go
+++ b/identity/eth_witness.go
@@ -1,0 +1,31 @@
+package identity
+
+import (
+	"github.com/Oneledger/protocol/data/keys"
+	"github.com/Oneledger/protocol/serialize"
+)
+
+type EthWitness struct {
+	Address     keys.Address   `json:"address"`
+	PubKey      keys.PublicKey `json:"pubKey"`
+	ECDSAPubKey keys.PublicKey `json:"ecdsaPubkey"`
+	Name        string         `json:"name"`
+}
+
+func (w *EthWitness) Bytes() []byte {
+	value, err := serialize.GetSerializer(serialize.PERSISTENT).Serialize(w)
+	if err != nil {
+		logger.Error("ethereum witness not serializable", err)
+		return []byte{}
+	}
+	return value
+}
+
+func (w *EthWitness) FromBytes(msg []byte) (*EthWitness, error) {
+	err := serialize.GetSerializer(serialize.PERSISTENT).Deserialize(msg, w)
+	if err != nil {
+		logger.Error("failed to deserialize ethereum witness from bytes", err)
+		return nil, err
+	}
+	return w, nil
+}

--- a/identity/eth_witness_set.go
+++ b/identity/eth_witness_set.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var isETHWitness bool
+var fnIsETHWitness func() bool
 
 type EthWitnessStore struct {
 	prefix []byte
@@ -26,7 +26,10 @@ func (ws *EthWitnessStore) WithState(state *storage.State) *EthWitnessStore {
 }
 
 func (ws *EthWitnessStore) Init(nodeValidatorAddress keys.Address) {
-	isETHWitness = ws.Exists(nodeValidatorAddress)
+	isETHWitness := ws.Exists(nodeValidatorAddress)
+	fnIsETHWitness = func() bool {
+		return isETHWitness
+	}
 }
 
 func (ws *EthWitnessStore) Get(addr keys.Address) (*EthWitness, error) {
@@ -77,7 +80,7 @@ func (ws *EthWitnessStore) GetETHWitnessAddresses() ([]keys.Address, error) {
 
 // This node is a ethereum witness or not
 func (ws *EthWitnessStore) IsETHWitness() bool {
-	return isETHWitness
+	return fnIsETHWitness()
 }
 
 func (ws *EthWitnessStore) IsETHWitnessAddress(addr keys.Address) bool {

--- a/identity/eth_witness_set.go
+++ b/identity/eth_witness_set.go
@@ -1,0 +1,108 @@
+package identity
+
+import (
+	"github.com/Oneledger/protocol/data/keys"
+	"github.com/Oneledger/protocol/storage"
+	"github.com/pkg/errors"
+)
+
+var isETHWitness bool
+
+type EthWitnessStore struct {
+	prefix []byte
+	store  *storage.State
+}
+
+func NewEthWitnessStore(prefix string, state *storage.State) *EthWitnessStore {
+	return &EthWitnessStore{
+		prefix: storage.Prefix(prefix),
+		store:  state,
+	}
+}
+
+func (ws *EthWitnessStore) WithState(state *storage.State) *EthWitnessStore {
+	ws.store = state
+	return ws
+}
+
+func (ws *EthWitnessStore) Init(nodeValidatorAddress keys.Address) {
+	isETHWitness = ws.Exists(nodeValidatorAddress)
+}
+
+func (ws *EthWitnessStore) Get(addr keys.Address) (*EthWitness, error) {
+	key := append(ws.prefix, addr...)
+	value, _ := ws.store.Get(key)
+	if value == nil {
+		return nil, errors.New("failed to get ethereum witness from store")
+	}
+	witness := &EthWitness{}
+	witness, err := witness.FromBytes(value)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize ethereum witness")
+	}
+	return witness, nil
+}
+
+func (ws *EthWitnessStore) Exists(addr keys.Address) bool {
+	key := append(ws.prefix, addr...)
+	return ws.store.Exists(key)
+}
+
+func (ws *EthWitnessStore) Iterate(fn func(addr keys.Address, witness *EthWitness) bool) (stopped bool) {
+	return ws.store.IterateRange(
+		ws.prefix,
+		storage.Rangefix(string(ws.prefix)),
+		true,
+		func(key, value []byte) bool {
+			witness, err := (&EthWitness{}).FromBytes(value)
+			if err != nil {
+				logger.Error("failed to deserialize ethereum witness")
+				return false
+			}
+			addr := key[len(ws.prefix):]
+			return fn(addr, witness)
+		},
+	)
+}
+
+// Get Ethereum witness addresses
+func (ws *EthWitnessStore) GetETHWitnessAddresses() ([]keys.Address, error) {
+	witnessList := make([]keys.Address, 0)
+	ws.Iterate(func(addr keys.Address, witness *EthWitness) bool {
+		witnessList = append(witnessList, addr)
+		return false
+	})
+	return witnessList, nil
+}
+
+// This node is a ethereum witness or not
+func (ws *EthWitnessStore) IsETHWitness() bool {
+	return isETHWitness
+}
+
+func (ws *EthWitnessStore) IsETHWitnessAddress(addr keys.Address) bool {
+	return ws.Exists(addr)
+}
+
+// Add a ethereum witness to store
+func (ws *EthWitnessStore) AddWitness(apply Stake) error {
+	if ws.Exists(apply.ValidatorAddress) {
+		return nil
+	}
+
+	witness := &EthWitness{
+		Address:     apply.ValidatorAddress,
+		PubKey:      apply.Pubkey,
+		ECDSAPubKey: apply.ECDSAPubKey,
+		Name:        apply.Name,
+	}
+
+	value := witness.Bytes()
+	vkey := append(ws.prefix, witness.Address.Bytes()...)
+	err := ws.store.Set(vkey, value)
+	if err != nil {
+		return errors.Wrap(err, "failed to add ethereum witness")
+	}
+
+	return nil
+}

--- a/identity/eth_witness_set_test.go
+++ b/identity/eth_witness_set_test.go
@@ -1,0 +1,155 @@
+package identity
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/tendermint/tendermint/libs/db"
+
+	"github.com/Oneledger/protocol/storage"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Oneledger/protocol/data/keys"
+)
+
+// test setup
+func setupEthWitnessStore() *EthWitnessStore {
+	db := db.NewDB("test", db.MemDBBackend, "")
+	cs := storage.NewChainState("chainstate", db)
+	ws := NewEthWitnessStore("etw", storage.NewState(cs))
+	return ws
+}
+
+func setupInitialEthWitness(ws *EthWitnessStore) []keys.Address {
+	addresses := make([]keys.Address, 4)
+	addr0, _ := hex.DecodeString("72143ADE3D941025468792311A0AB38D5085E15A")
+	addr1, _ := hex.DecodeString("A21437DF3C9410254A8792311A0A13255085E157")
+	addr2, _ := hex.DecodeString("B2143CDE3D941025468792311A0AB38D5085E151")
+	addr3, _ := hex.DecodeString("F2143AD5793B910D9410225ADC68B38D5085E11C")
+	addresses[0] = addr0
+	addresses[1] = addr1
+	addresses[2] = addr2
+	addresses[3] = addr3
+
+	stakes := make([]Stake, 2)
+	stakes[0] = Stake{
+		ValidatorAddress: addr0,
+		StakeAddress:     addr0,
+		Pubkey: keys.PublicKey{
+			KeyType: keys.ED25519,
+			Data:    nil,
+		},
+		Name: "test_node0",
+	}
+	stakes[1] = Stake{
+		ValidatorAddress: addr1,
+		StakeAddress:     addr1,
+		Pubkey: keys.PublicKey{
+			KeyType: keys.ED25519,
+			Data:    nil,
+		},
+		Name: "test_node1",
+	}
+
+	for _, stake := range stakes {
+		ws.AddWitness(stake)
+	}
+
+	ws.store.Commit()
+
+	return addresses
+}
+
+func TestNewEthWitnessStore(t *testing.T) {
+	ws := setupEthWitnessStore()
+	assert.NotEmpty(t, ws)
+}
+
+func TestEthWitnessStore_Init_IsETHWitness(t *testing.T) {
+	t.Run("run with witness node, should return true", func(t *testing.T) {
+		ws := setupEthWitnessStore()
+		addrs := setupInitialEthWitness(ws)
+		ws.Init(addrs[0])
+		assert.Equal(t, true, ws.IsETHWitness())
+	})
+	t.Run("run with non-witness node, should return false", func(t *testing.T) {
+		ws := setupEthWitnessStore()
+		addrs := setupInitialEthWitness(ws)
+		ws.Init(addrs[2])
+		assert.Equal(t, false, ws.IsETHWitness())
+	})
+}
+
+func TestEthWitnessStore_Get_Exists(t *testing.T) {
+	t.Run("get by valid witness address", func(t *testing.T) {
+		ws := setupEthWitnessStore()
+		addrs := setupInitialEthWitness(ws)
+		exist := ws.Exists(addrs[0])
+		assert.True(t, exist)
+
+		witness, err := ws.Get(addrs[0])
+		assert.Nil(t, err)
+		assert.NotNil(t, witness)
+		assert.Equal(t, witness.Address, addrs[0])
+	})
+	t.Run("get by invalid witness address", func(t *testing.T) {
+		ws := setupEthWitnessStore()
+		addrs := setupInitialEthWitness(ws)
+		exist := ws.Exists(addrs[2])
+		assert.False(t, exist)
+
+		witness, err := ws.Get(addrs[2])
+		assert.Nil(t, witness)
+		assert.EqualError(t, err, "failed to get ethereum witness from store")
+	})
+}
+
+func TestEthWitnessStore_Iterate(t *testing.T) {
+	ws := setupEthWitnessStore()
+	addrs := setupInitialEthWitness(ws)
+	addrs_expected := addrs[:2]
+
+	addrs_actual := []keys.Address{}
+	ws.Iterate(func(addr keys.Address, witness *EthWitness) bool {
+		addrs_actual = append(addrs_actual, addr)
+		return false
+	})
+	assert.Equal(t, addrs_expected, addrs_actual)
+}
+
+func TestEthWitnessStore_GetETHWitnessAddresses(t *testing.T) {
+	ws := setupEthWitnessStore()
+	addrs := setupInitialEthWitness(ws)
+	addrs_expected := addrs[:2]
+	addrs_actual, _ := ws.GetETHWitnessAddresses()
+	assert.EqualValues(t, addrs_expected, addrs_actual)
+}
+
+func TestEthWitnessStore_IsETHWitnessAddress(t *testing.T) {
+	ws := setupEthWitnessStore()
+	addrs := setupInitialEthWitness(ws)
+	assert.True(t, ws.IsETHWitnessAddress(addrs[0]))
+	assert.True(t, ws.IsETHWitnessAddress(addrs[1]))
+	assert.False(t, ws.IsETHWitnessAddress(addrs[2]))
+	assert.False(t, ws.IsETHWitnessAddress(addrs[3]))
+}
+
+func TestEthWitnessStore_AddWitness(t *testing.T) {
+	ws := setupEthWitnessStore()
+	addr, _ := hex.DecodeString("F2143AD5793BA10D9410225ADC68B38D5085E11C")
+	stake := Stake{
+		ValidatorAddress: addr,
+		StakeAddress:     addr,
+		Pubkey: keys.PublicKey{
+			KeyType: keys.ED25519,
+			Data:    nil,
+		},
+		Name: "test_node_new",
+	}
+	err := ws.AddWitness(stake)
+	assert.Nil(t, err)
+	witness, err = ws.Get(addr)
+	assert.Nil(t, err)
+	assert.Equal(t, keys.Address(addr), witness.Address)
+}

--- a/identity/eth_witness_test.go
+++ b/identity/eth_witness_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	nodeAddr, _ = hex.DecodeString("F2143ADE3D941025468792311A0AB38D5085E15A")
-	witness     = &EthWitness{
+	witness     = &Witness{
 		Address: nodeAddr,
 		PubKey: keys.PublicKey{
 			KeyType: keys.ED25519,
@@ -26,7 +26,7 @@ func TestETHWitness_Bytes(t *testing.T) {
 
 func TestETHWitness_FromBytes(t *testing.T) {
 	value := witness.Bytes()
-	witness_after := &EthWitness{}
+	witness_after := &Witness{}
 	witness_after, err := witness_after.FromBytes(value)
 	if assert.NoError(t, err) {
 		assert.Equal(t, witness, witness_after)

--- a/identity/eth_witness_test.go
+++ b/identity/eth_witness_test.go
@@ -1,0 +1,34 @@
+package identity
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/Oneledger/protocol/data/keys"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	nodeAddr, _ = hex.DecodeString("F2143ADE3D941025468792311A0AB38D5085E15A")
+	witness     = &EthWitness{
+		Address: nodeAddr,
+		PubKey: keys.PublicKey{
+			KeyType: keys.ED25519,
+			Data:    nil,
+		},
+		Name: "test_node",
+	}
+)
+
+func TestETHWitness_Bytes(t *testing.T) {
+	assert.NotEqual(t, []byte{}, witness.Bytes())
+}
+
+func TestETHWitness_FromBytes(t *testing.T) {
+	value := witness.Bytes()
+	witness_after := &EthWitness{}
+	witness_after, err := witness_after.FromBytes(value)
+	if assert.NoError(t, err) {
+		assert.Equal(t, witness, witness_after)
+	}
+}

--- a/service/broadcast/service.go
+++ b/service/broadcast/service.go
@@ -60,7 +60,7 @@ func (svc *Service) validateAndSignTx(req client.BroadcastRequest) ([]byte, erro
 
 	handler := svc.router.Handler(tx.Type)
 	ctx := action.NewContext(svc.router, nil, nil, nil, nil, svc.currencies,
-		svc.feePool, nil, svc.domains, svc.trackers, nil, nil, nil,
+		svc.feePool, nil, nil, svc.domains, svc.trackers, nil, nil, nil,
 		svc.logger)
 
 	_, err = handler.Validate(ctx, signedTx)


### PR DESCRIPTION
Currently the Validator also witnesses all interoperability Tx.  In the future we would like to remove the witness process from the Validator Nodes, so that it's not burdened with signing the Transactions.  For this story we would like to label the current Validators as witnesses as a first step to create a Witness Node.