### PR TITLE
OLP-845: Passing orderby value for txSearch under client services for…

### DIFF
--- a/client/service_context.go
+++ b/client/service_context.go
@@ -126,9 +126,9 @@ func (ctx ExtServiceContext) Block(height int64) (res *ctypes.ResultBlock) {
 	return result
 }
 
-func (ctx ExtServiceContext) Search(query string, prove bool, page, perPage int) (res *ctypes.ResultTxSearch) {
+func (ctx ExtServiceContext) Search(query string, prove bool, page, perPage int, orderBy string) (res *ctypes.ResultTxSearch) {
 
-	result, err := ctx.rpcClient.TxSearch(query, prove, page, perPage, "")
+	result, err := ctx.rpcClient.TxSearch(query, prove, page, perPage, orderBy)
 	if err != nil {
 		logger.Error("TxSearch Error", "err", err)
 		return nil

--- a/data/accounts/wallet.go
+++ b/data/accounts/wallet.go
@@ -181,6 +181,5 @@ func NewWallet(config config.Server, dbDir string) Wallet {
 }
 
 func (ws WalletStore) Close() error {
-	ws.store.Close()
-	return nil
+	return ws.store.Close()
 }

--- a/storage/keyvalue.go
+++ b/storage/keyvalue.go
@@ -147,7 +147,8 @@ func (store KeyValue) Errors() string {
 }
 
 // Close the database
-func (store KeyValue) Close() {
+func (store KeyValue) Close() error {
+	var err error = nil
 	switch store.Type {
 
 	case MEMORY:
@@ -155,12 +156,13 @@ func (store KeyValue) Close() {
 
 	case PERSISTENT:
 		store.tree = nil
-		store.database.Close()
+		err = store.database.Close()
 		store.database = nil
 
 	default:
 		panic("Unknown Type")
 	}
+	return err
 }
 
 // FindAll of the keys in the database

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -29,7 +29,7 @@ type SessionedStorage interface {
 	Exists(StoreKey) (bool, error)
 
 	BeginSession() Session
-	Close()
+	Close() error
 }
 
 // Session defines a session-ed storage object of your choice


### PR DESCRIPTION
… tendermint. Also modified session storage to return an error from close() function.