### PR TITLE
Redeem hotfix

### DIFF
--- a/app/application.go
+++ b/app/application.go
@@ -371,19 +371,30 @@ func (app *App) Prepare() error {
 
 // Start initializes the state
 func (app *App) Start() error {
-	app.logger.Info("Starting node...")
 
 	err := app.Prepare()
 	if err != nil {
 		return err
 	}
+	// Adding internal Router
+	internalRouter := action.NewRouter("internal")
+	err = eth.EnableInternalETH(internalRouter)
+	if err != nil {
+		app.logger.Error("failed to register eth internal transaction")
+		return err
+	}
+	app.Context.internalService = event.NewService(app.Context.node,
+		log.NewLoggerWithPrefix(app.Context.logWriter, "internal_service"), internalRouter, app.node)
 
+	// Starting App
 	err = app.node.Start()
 	if err != nil {
 		app.logger.Error("Failed to start consensus.Node")
 		return errors.Wrap(err, "failed to start new consensus.Node")
 	}
-
+	//Start Jobbus
+	_ = app.Context.jobBus.Start(app.Context.JobContext())
+	// Starting RPC
 	startRPC, err := app.rpcStarter()
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare rpc service")
@@ -395,23 +406,12 @@ func (app *App) Start() error {
 		return err
 	}
 
-	internalRouter := action.NewRouter("internal")
 	//"btc" service temporarily disabled
 	//err = btc.EnableBTCInternalTx(internalRouter)
 	//if err != nil {
 	//	app.logger.Error("Failed to register btc internal transactions")
 	//	return err
 	//}
-	err = eth.EnableInternalETH(internalRouter)
-	if err != nil {
-		app.logger.Error("failed to register eth internal transaction")
-		return err
-	}
-
-	app.Context.internalService = event.NewService(app.Context.node,
-		log.NewLoggerWithPrefix(app.Context.logWriter, "internal_service"), internalRouter, app.node)
-
-	_ = app.Context.jobBus.Start(app.Context.JobContext())
 
 	return nil
 }

--- a/app/application.go
+++ b/app/application.go
@@ -365,6 +365,15 @@ func (app *App) Prepare() error {
 
 	// Init witness store after genesis witnesses loaded in above NewNode
 	app.Context.witnesses.Init(chain.ETHEREUM, app.Context.node.ValidatorAddress())
+	// Adding internal Router
+	internalRouter := action.NewRouter("internal")
+	err = eth.EnableInternalETH(internalRouter)
+	if err != nil {
+		app.logger.Error("failed to register eth internal transaction")
+		return err
+	}
+	app.Context.internalService = event.NewService(app.Context.node,
+		log.NewLoggerWithPrefix(app.Context.logWriter, "internal_service"), internalRouter, app.node)
 
 	return nil
 }
@@ -376,15 +385,6 @@ func (app *App) Start() error {
 	if err != nil {
 		return err
 	}
-	// Adding internal Router
-	internalRouter := action.NewRouter("internal")
-	err = eth.EnableInternalETH(internalRouter)
-	if err != nil {
-		app.logger.Error("failed to register eth internal transaction")
-		return err
-	}
-	app.Context.internalService = event.NewService(app.Context.node,
-		log.NewLoggerWithPrefix(app.Context.logWriter, "internal_service"), internalRouter, app.node)
 
 	// Starting App
 	err = app.node.Start()

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -231,21 +232,25 @@ func (acc *ETHChainDriver) CheckFinality(txHash TransactionHash, blockConfirmati
 
 // Bool value is for recipt status
 // Err is to handle error , we need to ignore NotFound and wait for the tx
-func (acc *ETHChainDriver) VerifyReceipt(txHash TransactionHash) VerifyReceiptStatus {
+func (acc *ETHChainDriver) VerifyReceipt(txHash TransactionHash) (VerifyReceiptStatus, error) {
+
 	result, err := acc.GetClient().TransactionReceipt(context.Background(), txHash)
-	if err == ethereum2.NotFound {
-		return NotFound
-	}
-	if result.Status == types.ReceiptStatusFailed {
-		return Failed
+	fmt.Println("Err : ", err)
+	fmt.Println("Result :", result)
+	if err == ethereum2.NotFound && result == nil {
+		return NotFound, nil
 	}
 	if err != nil {
-		return ConnectionError
+		return Other, err
+	}
+	if result.Status == types.ReceiptStatusFailed {
+		return Failed, nil
 	}
 	if result.Status == types.ReceiptStatusSuccessful {
-		return Found
+		return Found, nil
 	}
-	return Other
+	// Returning generic result ( no err )
+	return Other, nil
 }
 
 // BroadcastTx takes a signed transaction as input and broadcasts it to the network

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 
 const DefaultTimeout = 5 * time.Second
 const gasLimit = 700000
+const GasPriceMultiplier = "1"
 
 type ETHChainDriver struct {
 	cfg             *config.EthereumChainDriverConfig
@@ -139,6 +141,13 @@ func (acc *ETHChainDriver) SignRedeem(fromaddr common.Address, redeemAmount *big
 	}
 	gasLimit := uint64(gasLimit)
 	gasPrice, err := acc.GetClient().SuggestGasPrice(c)
+	n := new(big.Int)
+	n, ok := n.SetString(GasPriceMultiplier, 10)
+	if !ok {
+		fmt.Println("SetString: error")
+		return nil, errors.New("Unable to get multiplier for gas price")
+	}
+	gasPrice.Mul(gasPrice, n)
 	if err != nil {
 		return nil, err
 	}

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -18,6 +18,7 @@ import (
 )
 
 const DefaultTimeout = 5 * time.Second
+const gasLimit = 700000
 
 type ETHChainDriver struct {
 	cfg             *config.EthereumChainDriverConfig
@@ -136,7 +137,7 @@ func (acc *ETHChainDriver) SignRedeem(fromaddr common.Address, redeemAmount *big
 	if err != nil {
 		return nil, err
 	}
-	gasLimit := uint64(700000)
+	gasLimit := uint64(gasLimit)
 	gasPrice, err := acc.GetClient().SuggestGasPrice(c)
 	if err != nil {
 		return nil, err
@@ -162,7 +163,7 @@ func (acc *ETHChainDriver) PrepareUnsignedETHLock(addr common.Address, lockAmoun
 	if err != nil {
 		return nil, err
 	}
-	gasLimit := uint64(700000)
+	gasLimit := uint64(gasLimit)
 	gasPrice, err := acc.GetClient().SuggestGasPrice(c)
 	if err != nil {
 		return nil, err

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -19,7 +19,6 @@ import (
 
 const DefaultTimeout = 5 * time.Second
 const gasLimit = 700000
-const GasPriceMultiplier = "2"
 
 type ETHChainDriver struct {
 	cfg             *config.EthereumChainDriverConfig
@@ -145,7 +144,7 @@ func (acc *ETHChainDriver) SignRedeem(fromaddr common.Address, redeemAmount *big
 	if !ok {
 		return nil, errors.New("Unable to get multiplier for gas price")
 	}
-	gasPrice.Mul(gasPrice, n)
+	gasPrice = big.NewInt(0).Add(gasPrice, big.NewInt(0).Div(gasPrice, big.NewInt(2)))
 	if err != nil {
 		return nil, err
 	}

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -288,6 +288,7 @@ func (acc *ETHChainDriver) ParseRedeem(data []byte, abi string) (req *RedeemRequ
 //Ongoing : 0  (amount > 0 and until > block.number)
 //Success : 1  (amount = 0 and until < block.number)
 //Expired : 2  (amount > 0 and until < block.number)
+//ErrConnecting  : - 2  (Ethereum connection cannot be established)
 
 func (acc *ETHChainDriver) VerifyRedeem(validatorAddress common.Address, recipient common.Address) RedeemStatus {
 	instance := acc.GetContract()

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -2,7 +2,6 @@ package ethereum
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -20,7 +19,7 @@ import (
 
 const DefaultTimeout = 5 * time.Second
 const gasLimit = 700000
-const GasPriceMultiplier = "1"
+const GasPriceMultiplier = "2"
 
 type ETHChainDriver struct {
 	cfg             *config.EthereumChainDriverConfig
@@ -144,14 +143,12 @@ func (acc *ETHChainDriver) SignRedeem(fromaddr common.Address, redeemAmount *big
 	n := new(big.Int)
 	n, ok := n.SetString(GasPriceMultiplier, 10)
 	if !ok {
-		fmt.Println("SetString: error")
 		return nil, errors.New("Unable to get multiplier for gas price")
 	}
 	gasPrice.Mul(gasPrice, n)
 	if err != nil {
 		return nil, err
 	}
-
 	contractAbi, _ := abi.JSON(strings.NewReader(acc.ContractABI))
 	bytesData, err := contractAbi.Pack("sign", redeemAmount, recipient)
 	if err != nil {

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -139,11 +139,6 @@ func (acc *ETHChainDriver) SignRedeem(fromaddr common.Address, redeemAmount *big
 	}
 	gasLimit := uint64(gasLimit)
 	gasPrice, err := acc.GetClient().SuggestGasPrice(c)
-	n := new(big.Int)
-	n, ok := n.SetString(GasPriceMultiplier, 10)
-	if !ok {
-		return nil, errors.New("Unable to get multiplier for gas price")
-	}
 	gasPrice = big.NewInt(0).Add(gasPrice, big.NewInt(0).Div(gasPrice, big.NewInt(2)))
 	if err != nil {
 		return nil, err

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -2,7 +2,6 @@ package ethereum
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -235,8 +234,6 @@ func (acc *ETHChainDriver) CheckFinality(txHash TransactionHash, blockConfirmati
 func (acc *ETHChainDriver) VerifyReceipt(txHash TransactionHash) (VerifyReceiptStatus, error) {
 
 	result, err := acc.GetClient().TransactionReceipt(context.Background(), txHash)
-	fmt.Println("Err : ", err)
-	fmt.Println("Result :", result)
 	if err == ethereum2.NotFound && result == nil {
 		return NotFound, nil
 	}
@@ -317,6 +314,5 @@ func (acc *ETHChainDriver) VerifyRedeem(validatorAddress common.Address, recipie
 // HasValidatorSigned takes validator address and recipient address as input and verifies if the validator has already signed
 func (acc *ETHChainDriver) HasValidatorSigned(validatorAddress common.Address, recipient common.Address) (bool, error) {
 	instance := acc.GetContract()
-
 	return instance.HasValidatorSigned(acc.CallOpts(validatorAddress), recipient)
 }

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -295,10 +295,6 @@ func (acc *ETHChainDriver) VerifyRedeem(validatorAddress common.Address, recipie
 	if err != nil {
 		return ErrorConnecting
 	}
-	if redeemStatus == 2 {
-		return Expired
-	}
-
 	return RedeemStatus(redeemStatus)
 }
 

--- a/chains/ethereum/online_chain_driver.go
+++ b/chains/ethereum/online_chain_driver.go
@@ -136,7 +136,7 @@ func (acc *ETHChainDriver) SignRedeem(fromaddr common.Address, redeemAmount *big
 	if err != nil {
 		return nil, err
 	}
-	gasLimit := uint64(6721974)
+	gasLimit := uint64(700000)
 	gasPrice, err := acc.GetClient().SuggestGasPrice(c)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (acc *ETHChainDriver) PrepareUnsignedETHLock(addr common.Address, lockAmoun
 	if err != nil {
 		return nil, err
 	}
-	gasLimit := uint64(6721974)
+	gasLimit := uint64(700000)
 	gasPrice, err := acc.GetClient().SuggestGasPrice(c)
 	if err != nil {
 		return nil, err
@@ -289,17 +289,17 @@ func (acc *ETHChainDriver) ParseRedeem(data []byte, abi string) (req *RedeemRequ
 //Success : 1  (amount = 0 and until < block.number)
 //Expired : 2  (amount > 0 and until < block.number)
 
-func (acc *ETHChainDriver) VerifyRedeem(validatorAddress common.Address, recipient common.Address) (RedeemStatus, error) {
+func (acc *ETHChainDriver) VerifyRedeem(validatorAddress common.Address, recipient common.Address) RedeemStatus {
 	instance := acc.GetContract()
 	redeemStatus, err := instance.VerifyRedeem(acc.CallOpts(validatorAddress), recipient)
 	if err != nil {
-		return -2, errors.Wrap(err, "Unable to connect to ethereum smart contract")
+		return ErrorConnecting
 	}
 	if redeemStatus == 2 {
-		return 0, ErrRedeemExpired
+		return Expired
 	}
 
-	return RedeemStatus(redeemStatus), nil
+	return RedeemStatus(redeemStatus)
 }
 
 // HasValidatorSigned takes validator address and recipient address as input and verifies if the validator has already signed

--- a/chains/ethereum/types.go
+++ b/chains/ethereum/types.go
@@ -13,10 +13,11 @@ import (
 type RedeemStatus int8
 
 const (
-	NewRedeem RedeemStatus = -1
-	Ongoing   RedeemStatus = 0
-	Success   RedeemStatus = 1
-	Expired   RedeemStatus = 2
+	NewRedeem       RedeemStatus = -1
+	Ongoing         RedeemStatus = 0
+	Success         RedeemStatus = 1
+	Expired         RedeemStatus = 2
+	ErrorConnecting RedeemStatus = -2
 )
 
 func (r RedeemStatus) String() string {
@@ -29,6 +30,8 @@ func (r RedeemStatus) String() string {
 		return "Success"
 	case 2:
 		return "Expired"
+	case 3:
+		return "Error connecting to ethereum"
 	}
 	return "Unknown Type / Check smart contract implementation"
 }

--- a/chains/ethereum/types.go
+++ b/chains/ethereum/types.go
@@ -48,6 +48,16 @@ const (
 	TXSuccess              CheckFinalityStatus = 0x07
 )
 
+type VerifyReceiptStatus int8
+
+const (
+	NotFound        VerifyReceiptStatus = 0
+	Found           VerifyReceiptStatus = 1
+	Failed          VerifyReceiptStatus = 2
+	ConnectionError VerifyReceiptStatus = 3
+	Other           VerifyReceiptStatus = 4
+)
+
 type RedeemRequest struct {
 	Amount *big.Int
 }

--- a/event/eth_redeem_transitions.go
+++ b/event/eth_redeem_transitions.go
@@ -174,7 +174,7 @@ func redeemCleanup(ctx interface{}) error {
 		}
 	}
 	//Delete Tracker
-	context.Logger.Debug("Setting Tracker to succeeded (ethLock):", tracker.State.String())
+	context.Logger.Debug("Setting Tracker to succeeded (ethRedeem):", tracker.State.String())
 	err := context.TrackerStore.WithPrefixType(ethereum.PrefixPassed).Set(tracker.Clean())
 	if err != nil {
 		context.Logger.Error("error saving eth tracker", err)
@@ -211,7 +211,7 @@ func redeemCleanupFailed(ctx interface{}) error {
 		}
 	}
 	//Delete Tracker
-	context.Logger.Debug("Setting Tracker to Failed (ethLock):", tracker.State.String())
+	context.Logger.Debug("Setting Tracker to Failed (ethRedeem):", tracker.State.String())
 	err := context.TrackerStore.WithPrefixType(ethereum.PrefixFailed).Set(tracker.Clean())
 	if err != nil {
 		context.Logger.Error("error saving eth tracker", err)

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -105,18 +105,19 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		return
 	}
 	/*
-			Points to note
+		              Points to note
 
-		    If expired fail tracker
+		              If expired fail tracker
 
-			If Success is true and validator has send signature implies , validator has signed , but his sign got reverted
-			as this was the fourth sign .
+		              Success ( Validator sign has been broadcasted and cofirmed on the ethereum blockchain)
+					        If Success is true and validator has send signature implies , validator has signed , but his sign got reverted
+							as this was the fourth sign .
 
-		    Retrycount > 0 means that the validator did sign , status was 0 before ,implies this is not an old redeem
+			          Retrycount incremented only when validator broadacasts signature
 
-			Status is not 0 , and txreceipt is true , redeem tx present in Ethereum ,but redeem status is not ongoing Fail tracker .
+				      Status is not ongoing , and txreceipt is true , redeem tx present in Ethereum ,but redeem status is not ongoing Fail tracker .
 
-			HasValidatorsigned returns success , means signature confirmed
+		              HasValidatorsigned returns success , means signature confirmed
 	*/
 
 	//Checking for confirmation of Vote
@@ -131,7 +132,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		return
 	}
 	//Log print debugger
-	if j.RetryCount >= 0 && !success {
+	if j.RetryCount >= 0 {
 		ethCtx.Logger.Debug("Waiting for validator SignTX to be mined")
 	}
 

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -140,8 +140,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 
 	//Ethereum connectivity issue
 	if status == ethereum.ErrorConnecting {
-		ethCtx.Logger.Error("Unable to connect to ethereum smartcontract")
-		return
+		panic("Unable to connect to ethereum")
 	}
 
 	// Redeem request has expired

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -144,7 +144,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		panic("Error connecting to HasValidatorSigned function in Smart Contract ")
 	}
 	//Signature confirmed
-	if success && err != nil {
+	if success {
 		ethCtx.Logger.Debug("validator Sign Confirmed | validator Address (SIGNER):", ethCtx.GetValidatorETHAddress().Hex(), "| User Eth Address :", msg.From().Hex())
 		j.Status = jobs.Completed
 		return
@@ -158,7 +158,8 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 	status := cd.VerifyRedeem(addr, msg.From())
 	//Ethereum connectivity issue
 	if status == ethereum.ErrorConnecting {
-		ethCtx.Logger.Error("Error connecting to HasValidatorSigned function in Smart Contract  :", j.GetJobID(), err) //TODO : Possible panic
+		ethCtx.Logger.Error("Error connecting to HasValidatorSigned function in Smart Contract  :", j.GetJobID(), err)
+		panic(fmt.Sprintf("Error connecting to HasValidatorSigned function in Smart Contract %s, %s :", j.GetJobID(), err))
 	}
 
 	// Redeem request has expired
@@ -188,7 +189,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		return
 	}
 
-	//Signing done only once
+	//Signing done only once after redeem receipt has been confirmed
 	if j.RetryCount == 0 && txReceipt == ethereum.Found {
 
 		redeemAddr := common.BytesToAddress(tracker.To)

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -108,7 +108,8 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		panic("Shutting down node ,unable to process redeem Transaction")
 	}
 	if txReceipt == ethereum.Failed {
-		ethCtx.Logger.Debug("Transaction receipt not found | Failing Tracker:", err)
+		// TX included in uncle block , or TX reverted ( not enough redeem fee)
+		ethCtx.Logger.Debug("Transaction receipt Failed  | Failing Tracker:", err)
 		j.Status = jobs.Failed
 		err := BroadcastReportFinalityETHTx(ctx.(*JobsContext), j.TrackerName, j.JobID, false)
 		if err != nil {
@@ -117,7 +118,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		return
 	}
 	if txReceipt == ethereum.NotFound {
-		ethCtx.Logger.Debug("Transaction receipt not found ,Waiting for TX receipt", err)
+		ethCtx.Logger.Debug("Waiting for User Redeem TX to be mined", err)
 		return
 	}
 
@@ -149,9 +150,9 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		j.Status = jobs.Completed
 		return
 	}
-	//Log print debugger
+	//Log print debugger , Sign has been broadcast but not mined yet
 	if j.RetryCount >= 0 {
-		ethCtx.Logger.Debug("Waiting for validator SignTX to be mined")
+		ethCtx.Logger.Debug("Waiting for Validator SignTX to be mined")
 	}
 
 	//Checking for Status of redeem request (From Ethereum smart contract)

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -141,7 +141,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 	//Ethereum connectivity issue
 	if status == ethereum.ErrorConnecting {
 		ethCtx.Logger.Error("Unable to connect to ethereum smartcontract")
-		panic("SHUTTING NODE ERROR CONNECTING TO ETHEREUM ")
+		return
 	}
 
 	// Redeem request has expired

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -101,10 +101,10 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 	//Get receipt first ,then status [ other way around might cause ambiguity ]
 	//Confirm redeem tx has been sent by user
 	//Verify Redeem should only be checked after Verify Receipt is confirmed , otherwise we might get stale verify redeem
-	//Verify Recipt returns
-	txReceipt := cd.VerifyReceipt(tx.Hash())
-	if txReceipt != ethereum.ConnectionError {
-		ethCtx.Logger.Debug("Error in Getting TX receipt:")
+	//Verify Receipt returns
+	txReceipt, err := cd.VerifyReceipt(tx.Hash())
+	if err != nil {
+		ethCtx.Logger.Debug("Error in Getting TX receipt:", err)
 		panic("Shutting down node ,unable to process redeem Transaction")
 	}
 	if txReceipt == ethereum.Failed {

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -141,7 +141,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 	}
 
 	// Redeem request has expired
-	if err == ethereum.ErrRedeemExpired {
+	if status == ethereum.Expired {
 		ethCtx.Logger.Info("Failing from sign : Redeem Expired")
 		j.Status = jobs.Failed
 		BroadcastReportFinalityETHTx(ctx.(*JobsContext), j.TrackerName, j.JobID, false)

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -105,15 +105,19 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		return
 	}
 	/*
-		If expired fail tracker
+			Points to note
 
-		If Success is true and validator has send signature implies , validator has signed , but his sign got reverted
-		as this was the fourth sign . Retrycount > 0 means that the validator did sign , status was 0 before ,implies
-		this is not an old redeem
+		    If expired fail tracker
 
-		Status is not 0 , and txreceipt is true , redeem tx present in Ethereum ,but redeem status is not ongoing .Fail tracker
+			If Success is true and validator has send signature implies , validator has signed , but his sign got reverted
+			as this was the fourth sign .
 
-		HasValidatorsigned returns success , means signature confirmed */
+		    Retrycount > 0 means that the validator did sign , status was 0 before ,implies this is not an old redeem
+
+			Status is not 0 , and txreceipt is true , redeem tx present in Ethereum ,but redeem status is not ongoing Fail tracker .
+
+			HasValidatorsigned returns success , means signature confirmed
+	*/
 
 	//Checking for confirmation of Vote
 	success, err := cd.HasValidatorSigned(addr, msg.From())

--- a/event/eth_sign_redeem.go
+++ b/event/eth_sign_redeem.go
@@ -118,7 +118,7 @@ func (j *JobETHSignRedeem) DoMyJob(ctx interface{}) {
 		return
 	}
 	if txReceipt == ethereum.NotFound {
-		ethCtx.Logger.Debug("Waiting for User Redeem TX to be mined", err)
+		ethCtx.Logger.Debug("Waiting for User Redeem TX to be mined")
 		return
 	}
 

--- a/event/eth_verify_redeem.go
+++ b/event/eth_verify_redeem.go
@@ -73,7 +73,7 @@ func (job *JobETHVerifyRedeem) DoMyJob(ctx interface{}) {
 	status := cd.VerifyRedeem(addr, msg.From())
 	if status == ethereum.ErrorConnecting {
 		ethCtx.Logger.Error("Error connecting to HasValidatorSigned function in Smart Contract  :", job.JobID, err)
-		panic("Error connecting  to Smart Contract ") //TODO : Possible panic
+		panic("Error connecting  to Smart Contract ")
 	}
 	if status == ethereum.Expired {
 		job.Status = jobs.Failed

--- a/event/eth_verify_redeem.go
+++ b/event/eth_verify_redeem.go
@@ -73,8 +73,7 @@ func (job *JobETHVerifyRedeem) DoMyJob(ctx interface{}) {
 	addr := ethCtx.GetValidatorETHAddress()
 	status := cd.VerifyRedeem(addr, msg.From())
 	if status == ethereum.ErrorConnecting {
-		ethCtx.Logger.Error("Unable to connect to ethereum smartcontract")
-		return
+		panic("Unable to connect to ethereum")
 	}
 	if status == ethereum.Expired {
 		job.Status = jobs.Failed

--- a/event/eth_verify_redeem.go
+++ b/event/eth_verify_redeem.go
@@ -79,7 +79,7 @@ func (job *JobETHVerifyRedeem) DoMyJob(ctx interface{}) {
 		job.Status = jobs.Failed
 		err := BroadcastReportFinalityETHTx(ctx.(*JobsContext), job.TrackerName, job.JobID, false)
 		if err != nil {
-			panic(fmt.Sprintf("Unable to broadcast failed TX for : %s ", job.JobID))
+			panic(fmt.Sprintf("Unable to broadcast failed TX for : %s %s", job.JobID, err))
 		}
 
 		return

--- a/event/eth_verify_redeem.go
+++ b/event/eth_verify_redeem.go
@@ -73,7 +73,8 @@ func (job *JobETHVerifyRedeem) DoMyJob(ctx interface{}) {
 	addr := ethCtx.GetValidatorETHAddress()
 	status := cd.VerifyRedeem(addr, msg.From())
 	if status == ethereum.ErrorConnecting {
-		panic("Shutting down Node , Ethereum connection not available")
+		ethCtx.Logger.Error("Unable to connect to ethereum smartcontract")
+		return
 	}
 	if status == ethereum.Expired {
 		job.Status = jobs.Failed

--- a/event/internal_service.go
+++ b/event/internal_service.go
@@ -107,13 +107,11 @@ func (svc Service) InternalBroadcast(request InternalBroadcastRequest, reply *Br
 func BroadcastReportFinalityETHTx(ethCtx *JobsContext, trackerName ethereum.TrackerName, jobID string, success bool) error {
 
 	trackerStore := ethCtx.EthereumTrackers
-	tracker, err := trackerStore.WithPrefixType(ethereum2.PrefixOngoing).Get(trackerName)
+	tracker, err := trackerStore.QueryAllStores(trackerName)
 	if err != nil {
-		tracker, err := trackerStore.QueryAllStores(trackerName)
-		if err != nil {
-			return err
-		}
-		ethCtx.Logger.Debug("Tracker already : ", tracker.State.String())
+		return err
+	}
+	if tracker.State == ethereum2.Released || tracker.State == ethereum2.Failed {
 		return nil
 	}
 	index, voted := tracker.CheckIfVoted(ethCtx.ValidatorAddress)

--- a/event/internal_service.go
+++ b/event/internal_service.go
@@ -108,8 +108,17 @@ func BroadcastReportFinalityETHTx(ethCtx *JobsContext, trackerName ethereum.Trac
 
 	trackerStore := ethCtx.EthereumTrackers
 	tracker, err := trackerStore.WithPrefixType(ethereum2.PrefixOngoing).Get(trackerName)
-	index, _ := tracker.CheckIfVoted(ethCtx.ValidatorAddress)
-	if index < 0 {
+	if err != nil {
+		tracker, err := trackerStore.QueryAllStores(trackerName)
+		if err != nil {
+			return err
+		}
+		ethCtx.Logger.Debug("Tracker already : ", tracker.State.String())
+		return nil
+	}
+	index, voted := tracker.CheckIfVoted(ethCtx.ValidatorAddress)
+	if voted {
+		//Validator has already Voted
 		return nil
 	}
 	reportFailed := &eth.ReportFinality{

--- a/event/internal_service.go
+++ b/event/internal_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Oneledger/protocol/consensus"
 	ethereum2 "github.com/Oneledger/protocol/data/ethereum"
 	"github.com/Oneledger/protocol/log"
+
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/libs/bytes"
@@ -102,6 +103,7 @@ func (svc Service) InternalBroadcast(request InternalBroadcastRequest, reply *Br
 
 }
 
+//^TODO Replace error with InternalBroadcastStatus
 func BroadcastReportFinalityETHTx(ethCtx *JobsContext, trackerName ethereum.TrackerName, jobID string, success bool) error {
 
 	trackerStore := ethCtx.EthereumTrackers

--- a/event/internal_service.go
+++ b/event/internal_service.go
@@ -110,7 +110,7 @@ func BroadcastReportFinalityETHTx(ethCtx *JobsContext, trackerName ethereum.Trac
 	tracker, err := trackerStore.WithPrefixType(ethereum2.PrefixOngoing).Get(trackerName)
 	index, _ := tracker.CheckIfVoted(ethCtx.ValidatorAddress)
 	if index < 0 {
-		return errors.New("validator already Voted")
+		return nil
 	}
 	reportFailed := &eth.ReportFinality{
 		TrackerName:      trackerName,

--- a/event/process.go
+++ b/event/process.go
@@ -74,6 +74,7 @@ func ProcessAllJobs(ctx *JobsContext, js *jobs.JobStore) {
 				if r := recover(); r != nil {
 					ctx.Logger.Info("panic in job: ", job.GetJobID())
 					ctx.Logger.Info(r)
+					panic(r)
 					debug.PrintStack()
 				}
 			}()


### PR DESCRIPTION
Tests 
Tested with old binary , Issue with 
- Insufficient funds for validator replicated
- Issue with redeem expiring before validator signature is mine replicated

Tested with fined binary 
- Tracker failer in both cases
- Oeth Refunded in both cases  
- Some validators loose connection to infura and panic .


more than 33% validators loose connection ,and panic
before we bring the nodes back up ,redeem expires ,and  validators cast there No votes ,
After Casting to no vote some of those validators also restart ,becuase of some reason
so there no votes are still in sessioncache and not chainstate ,when they come back up they wont have jobs fo signing ,and the tracker woud be missing that many number of votes