### PR TITLE
OLP-949

### DIFF
--- a/action/ons/purchase.go
+++ b/action/ons/purchase.go
@@ -176,7 +176,7 @@ func runPurchaseDomain(ctx *action.Context, tx action.RawTx) (bool, action.Respo
 		}
 
 		// credit the sale price to the previous owner
-		err = ctx.Balances.AddToAddress(domain.Beneficiary, sale)
+		err = ctx.Balances.AddToAddress(domain.Owner, sale)
 		if err != nil {
 			return false, action.Response{Log: err.Error()}
 		}


### PR DESCRIPTION
Purchase amount is credited to the owner address instead of the beneficiary.