### PR TITLE
added public key to result of show_node_id command

### DIFF
--- a/client/request_types.go
+++ b/client/request_types.go
@@ -141,7 +141,7 @@ type NodeIDRequest struct {
 	ShouldShowIP bool `json:"shouldShowIP,omitempty"`
 }
 type NodeIDReply struct {
-	PublicKey string `json:publicKey`
+	PublicKey string `json:"publicKey"`
 	Id        string `json:"id"`
 }
 

--- a/client/request_types.go
+++ b/client/request_types.go
@@ -141,7 +141,8 @@ type NodeIDRequest struct {
 	ShouldShowIP bool `json:"shouldShowIP,omitempty"`
 }
 type NodeIDReply struct {
-	Id string `json:"id"`
+	PublicKey string `json:publicKey`
+	Id        string `json:"id"`
 }
 
 type AddAccountRequest = accounts.Account

--- a/cmd/olclient/show_node_id.go
+++ b/cmd/olclient/show_node_id.go
@@ -44,5 +44,5 @@ func showNodeID(_ *cobra.Command, _ []string) {
 		ctx.logger.Error("failed to get node ID", err)
 		return
 	}
-	fmt.Println(out)
+	fmt.Println(fmt.Sprintf("publicKey: %s, id: %s", out.PublicKey, out.Id))
 }

--- a/cmd/olfullnode/show_node_id.go
+++ b/cmd/olfullnode/show_node_id.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 
 	"github.com/Oneledger/protocol/config"
 	"github.com/Oneledger/protocol/consensus"
+	"github.com/Oneledger/protocol/data/keys"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/p2p"
 )
@@ -64,6 +66,12 @@ func showNodeID(root string, shouldShowIP bool) (result string, err error) {
 		}
 		return fmt.Sprintf("%s@%s", nodeKey.ID(), u.Host), nil
 	} else {
-		return string(nodeKey.ID()), nil
+		pubKey, _ := keys.PubKeyFromTendermint(nodeKey.PubKey().Bytes())
+		encoded, _ := pubKey.GobEncode()
+		matches := regexp.MustCompile(`^{.*:.*,.*:"(.*)"}$`).FindStringSubmatch(string(encoded))
+		if len(matches) > 1 {
+			return fmt.Sprintf("publicKey: %s, id: %s", matches[1], nodeKey.ID()), nil
+		}
+		return fmt.Sprintf("publicKey: %s, id: %s", string(encoded), nodeKey.ID()), nil
 	}
 }

--- a/cmd/olfullnode/show_node_id.go
+++ b/cmd/olfullnode/show_node_id.go
@@ -58,20 +58,23 @@ func showNodeID(root string, shouldShowIP bool) (result string, err error) {
 		return result, err
 	}
 
+	// get public key text
+	pubKey, _ := keys.PubKeyFromTendermint(nodeKey.PubKey().Bytes())
+	encoded, _ := pubKey.GobEncode()
+	pubKeyText := string(encoded)
+	matches := regexp.MustCompile(`^{.*:.*,.*:"(.*)"}$`).FindStringSubmatch(pubKeyText)
+	if len(matches) > 1 {
+		pubKeyText = matches[1]
+	}
+
 	ip := configuration.CFG.P2P.ExternalAddress
 	if shouldShowIP {
 		u, err := url.Parse(ip)
 		if err != nil {
 			return result, err
 		}
-		return fmt.Sprintf("%s@%s", nodeKey.ID(), u.Host), nil
+		return fmt.Sprintf("publicKey: %s, id: %s@%s", pubKeyText, nodeKey.ID(), u.Host), nil
 	} else {
-		pubKey, _ := keys.PubKeyFromTendermint(nodeKey.PubKey().Bytes())
-		encoded, _ := pubKey.GobEncode()
-		matches := regexp.MustCompile(`^{.*:.*,.*:"(.*)"}$`).FindStringSubmatch(string(encoded))
-		if len(matches) > 1 {
-			return fmt.Sprintf("publicKey: %s, id: %s", matches[1], nodeKey.ID()), nil
-		}
-		return fmt.Sprintf("publicKey: %s, id: %s", string(encoded), nodeKey.ID()), nil
+		return fmt.Sprintf("publicKey: %s, id: %s", pubKeyText, nodeKey.ID()), nil
 	}
 }

--- a/service/node/service.go
+++ b/service/node/service.go
@@ -53,6 +53,15 @@ func (svc *Service) ID(req client.NodeIDRequest, reply *client.NodeIDReply) erro
 		return codes.ErrLoadingNodeKey
 	}
 
+	// get public key text
+	pubKey, _ := keys.PubKeyFromTendermint(nodeKey.PubKey().Bytes())
+	encoded, _ := pubKey.GobEncode()
+	pubKeyText := string(encoded)
+	matches := regexp.MustCompile(`^{.*:.*,.*:"(.*)"}$`).FindStringSubmatch(pubKeyText)
+	if len(matches) > 1 {
+		pubKeyText = matches[1]
+	}
+
 	// silenced error because not present means false
 	ip := p2pAddressFromCFG(svc.cfg)
 	if req.ShouldShowIP {
@@ -61,16 +70,9 @@ func (svc *Service) ID(req client.NodeIDRequest, reply *client.NodeIDReply) erro
 			return codes.ErrParsingAddress
 		}
 		out := fmt.Sprintf("%s@%s", nodeKey.ID(), u.Host)
-		*reply = client.NodeIDReply{Id: out}
+		*reply = client.NodeIDReply{PublicKey: pubKeyText, Id: out}
 	} else {
-		pubKey, _ := keys.PubKeyFromTendermint(nodeKey.PubKey().Bytes())
-		encoded, _ := pubKey.GobEncode()
-		matches := regexp.MustCompile(`^{.*:.*,.*:"(.*)"}$`).FindStringSubmatch(string(encoded))
-		if len(matches) > 1 {
-			*reply = client.NodeIDReply{PublicKey: matches[1], Id: string(nodeKey.ID())}
-		} else {
-			*reply = client.NodeIDReply{PublicKey: string(encoded), Id: string(nodeKey.ID())}
-		}
+		*reply = client.NodeIDReply{PublicKey: pubKeyText, Id: string(nodeKey.ID())}
 	}
 	return nil
 }
@@ -79,7 +81,7 @@ func (svc *Service) ID(req client.NodeIDRequest, reply *client.NodeIDReply) erro
 // not present from the config
 func p2pAddressFromCFG(cfg *config.Server) string {
 	extP2P := cfg.Network.ExternalP2PAddress
-	if extP2P != "" {
+	if extP2P == "" {
 		return cfg.Network.P2PAddress
 	}
 


### PR DESCRIPTION
1. We found a way to create a secure wallet account associated with genesis stake address.
2. Added public key information to 'olclient show_node_id' and 'olfullnode show_node_id', so node operator is able to create wallet account by specifying public key and their private key.