### PR TITLE
Fixed block rewards calculation in catching up scenario

### DIFF
--- a/data/rewards/store_cumulative.go
+++ b/data/rewards/store_cumulative.go
@@ -64,7 +64,7 @@ func (rws *RewardCumulativeStore) PullRewards(height int64, poolAmt *balance.Amo
 	}
 
 	// print this block's distribution
-	logger.Infof("Rewards pulled,   amount = %s, height = %v", amount, height)
+	logger.Detailf("Rewards pulled,   amount = %s, height = %v", amount, height)
 	return
 }
 
@@ -79,10 +79,11 @@ func (rws *RewardCumulativeStore) ConsumeRewards(consumed *balance.Amount) error
 	// accumulates year distributed rewards
 	calc := rws.calculator
 	if !calc.cached.burnedout {
-		err = rws.addYearDistributedRewards(calc.cached.year, consumed)
+		_, _, lastInCycle := rws.calculator.getCycleNo()
+		err = rws.addYearDistributedRewards(calc.cached.year, consumed, lastInCycle)
 	}
 
-	logger.Infof("Rewards consumed, amount = %s, year = %v", consumed, calc.cached.year+1)
+	logger.Detailf("Rewards consumed, amount = %s, year = %v", consumed, calc.cached.year+1)
 	return err
 }
 
@@ -261,9 +262,10 @@ func (rws *RewardCumulativeStore) initRewardYears(key storage.StoreKey) (rewards
 	for i := 0; i < numofYears; i++ {
 		tClose := tStart.AddDate(1, 0, 0).UTC()
 		reward := RewardYear{
-			StartTime:   tStart,
-			CloseTime:   tClose,
-			Distributed: balance.NewAmount(0),
+			StartTime:     tStart,
+			CloseTime:     tClose,
+			Distributed:   balance.NewAmount(0),
+			TillLastCycle: balance.NewAmount(0),
 		}
 		logger.Infof("Initial year-%v [start: %s], [close: %s]", i+1, tStart, tClose)
 		tStart = tClose
@@ -312,13 +314,19 @@ func (rws *RewardCumulativeStore) addTotalDistributedRewards(amount *balance.Amo
 }
 
 // Add to total year distributed rewards
-func (rws *RewardCumulativeStore) addYearDistributedRewards(year int, amount *balance.Amount) error {
+func (rws *RewardCumulativeStore) addYearDistributedRewards(year int, amount *balance.Amount, lastInCycle bool) error {
 	rewardYears, err := rws.GetYearDistributedRewards()
 	if err != nil {
 		return err
 	}
+
+	// save total distributed amount of the cycle if cycle is ending
 	yearDist := rewardYears.Years[year].Distributed
 	rewardYears.Years[year].Distributed = yearDist.Plus(*amount)
+	if lastInCycle {
+		rewardYears.Years[year].TillLastCycle = rewardYears.Years[year].Distributed
+		logger.Infof("Rewards till last cycle, amount = %s", rewardYears.Years[year].TillLastCycle)
+	}
 	key := rws.getYearDistributedKey()
 	err = rws.set(key, rewardYears)
 	return err

--- a/data/rewards/store_cumulative_test.go
+++ b/data/rewards/store_cumulative_test.go
@@ -115,9 +115,10 @@ func setupRewardYears(tStart time.Time) RewardYears {
 	for i := 0; i < numofYears; i++ {
 		tClose := tStart.AddDate(1, 0, 0).UTC()
 		reward := RewardYear{
-			StartTime:   tStart,
-			CloseTime:   tClose,
-			Distributed: balance.NewAmount(0),
+			StartTime:     tStart,
+			CloseTime:     tClose,
+			Distributed:   balance.NewAmount(0),
+			TillLastCycle: balance.NewAmount(0),
 		}
 		tStart = tClose
 		rewards.Years = append(rewards.Years, reward)
@@ -214,6 +215,9 @@ func TestRewardsCumulativeStore_PullRewards(t *testing.T) {
 		calc := store.calculator
 		year := calc.cached.year
 		years.Years[year].Distributed = years.Years[year].Distributed.Plus(*amount)
+		if (height)%store.rewardOptions.BlockSpeedCalculateCycle == 0 {
+			years.Years[year].TillLastCycle = years.Years[year].Distributed
+		}
 		assert.Equal(t, years, rewardYears)
 	}
 


### PR DESCRIPTION
The issue was caused by a different rewards amount from calculation when node is catching up blocks. A block's rewards amount is based on 2 factors, the block generation speed and the amount we have already distributed so far. The difference came from the second factor, the amount of rewards we have already distributed, in catch-up scenario. Now we persisted that amount in DB so we can get the same rewards amount even in catch-up mode.