### PR TITLE
Olp 1168 Query: Total rewards acquired by Delegation Pool in its entirety

### DIFF
--- a/client/network_delegation_request_types.go
+++ b/client/network_delegation_request_types.go
@@ -41,6 +41,13 @@ type GetDelegRewardsRequest struct {
 	InclPending bool         `json:"inclPending"`
 }
 
+type GetTotalDelegRewardsRequest struct{}
+
+type GetTotalDelegRewardsReply struct {
+	TotalRewards balance.Amount `json:"totalRewards"`
+	Height       int64          `json:"height"`
+}
+
 type GetDelegRewardsReply struct {
 	Balance balance.Amount                       `json:"balance"`
 	Pending []*network_delegation.PendingRewards `json:"pending"`

--- a/data/network_delegation/rewards_store.go
+++ b/data/network_delegation/rewards_store.go
@@ -45,13 +45,27 @@ func (drs *DelegRewardStore) AddRewardsBalance(delegator keys.Address, amount *b
 		return err
 	}
 
+	keyTotal := drs.getTotalRewardsKey()
+	amtTotal, err := drs.get(keyTotal)
+	if err != nil {
+		return err
+	}
+
 	err = drs.set(key, amt.Plus(*amount))
+	err = drs.set(keyTotal, amtTotal.Plus(*amount))
 	return err
 }
 
 // Get rewards balance
 func (drs *DelegRewardStore) GetRewardsBalance(delegator keys.Address) (amt *balance.Amount, err error) {
 	key := drs.getRewardsBalanceKey(delegator)
+	amt, err = drs.get(key)
+	return
+}
+
+// Get total rewards
+func (drs *DelegRewardStore) GetTotalRewards() (amt *balance.Amount, err error) {
+	key := drs.getTotalRewardsKey()
 	amt, err = drs.get(key)
 	return
 }
@@ -226,6 +240,12 @@ func (drs *DelegRewardStore) iteratePD(height int64, fn func(delegator keys.Addr
 // Key for delegator rewards balance
 func (drs *DelegRewardStore) getRewardsBalanceKey(delegator keys.Address) []byte {
 	key := fmt.Sprintf("%sbalance_%s", string(drs.prefix), delegator)
+	return storage.StoreKey(key)
+}
+
+// Key for total rewards
+func (drs *DelegRewardStore) getTotalRewardsKey() []byte {
+	key := fmt.Sprintf("%stotal_rewards", string(drs.prefix))
 	return storage.StoreKey(key)
 }
 

--- a/data/network_delegation/rewards_store_test.go
+++ b/data/network_delegation/rewards_store_test.go
@@ -209,3 +209,31 @@ func TestDelegRewardStore_Finalize(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, *matured, balance.AmtZero)
 }
+
+func TestGetTotalRewards(t *testing.T) {
+	setup()
+	curHeight := int64(8)
+	storeRwz.AddRewardsBalance(delegators[0], amt1)
+	storeRwz.AddRewardsBalance(delegators[0], amt2)
+	storeRwz.AddRewardsBalance(delegators[1], amt2)
+	storeRwz.AddRewardsBalance(delegators[1], amt3)
+
+	storeRwz.Withdraw(delegators[0], draw1, curHeight+delegOpt.RewardsMaturityTime)
+	storeRwz.Withdraw(delegators[0], draw2, curHeight+delegOpt.RewardsMaturityTime)
+	storeRwz.Withdraw(delegators[0], draw3, curHeight+delegOpt.RewardsMaturityTime+1)
+	storeRwz.Withdraw(delegators[1], draw3, curHeight+delegOpt.RewardsMaturityTime+1)
+
+	storeRwz.state.Commit()
+	storeRwz.MaturePendingRewards(curHeight + delegOpt.RewardsMaturityTime)
+
+	// finalizes all matured rewards for delegator[0]
+	err := storeRwz.Finalize(delegators[0], draw1.Plus(*draw2))
+	assert.Nil(t, err)
+	matured, err := storeRwz.GetMaturedRewards(delegators[0])
+	assert.Nil(t, err)
+	assert.Equal(t, *matured, balance.AmtZero)
+
+	// get total rewards that has been generated
+	totalRewards, err := storeRwz.GetTotalRewards()
+	assert.Equal(t, amt1.Plus(*amt2).Plus(*amt2).Plus(*amt3), totalRewards)
+}

--- a/scripts/network_delegation/finalizeRewards.py
+++ b/scripts/network_delegation/finalizeRewards.py
@@ -11,8 +11,8 @@ def delegate(node, account, amount):
 
 def check_rewards(result, balance, matured, pending):
     if balance != '':
-        balance = str(balance) + '0' * 18
-        if result['balance'] < balance:
+        balance = int(balance) * pow(10, 18)
+        if int(result['balance']) < balance:
             sys.exit(-1)
     if matured != '' and result['matured'] != matured:
         sys.exit(-1)
@@ -22,6 +22,11 @@ def check_rewards(result, balance, matured, pending):
         for i, amt in enumerate(pending):
             if amt != result['pending'][i]['amount']:
                 sys.exit(-1)
+
+
+def check_total_rewards(result, expected_exclude_withdrawn):
+    if result < expected_exclude_withdrawn:
+        sys.exit(-1)
 
 
 def check_balance(before, after, expected_diff):
@@ -66,8 +71,8 @@ if __name__ == "__main__":
 
     # query and check again after maturity
     wait_for(4)
-    res1 = query_rewards(delegator)
-    check_rewards(res1, '', total_str, [])
+    res = query_rewards(delegator)
+    check_rewards(res, '', total_str, [])
     print "#### Successfully matured delegator rewards"
 
     # finalize more than withdrawn
@@ -81,8 +86,8 @@ if __name__ == "__main__":
     finalize.send_finalize(total_str, True)
     # query and check
     wait_for(2)
-    res2 = query_rewards(delegator)
-    check_rewards(res2, '', '0', [])
+    res = query_rewards(delegator)
+    check_rewards(res, '', '0', [])
     balance_after = query_balance(delegator)
     check_balance(balance_before, balance_after, total)
     print bcolors.OKGREEN + "#### Successfully finalized delegator rewards" + bcolors.ENDC
@@ -98,8 +103,37 @@ if __name__ == "__main__":
     finalize.send_finalize(str(balance) + '0' * 18, True)
     # query and check
     wait_for(3)
-    res3 = query_rewards(delegator)
-    check_rewards(res3, '', '0', [])
+    res = query_rewards(delegator)
+    check_rewards(res, '', '0', [])
     balance_final = query_balance(delegator)
     check_balance(balance_after, balance_final, balance)
     print bcolors.OKGREEN + "#### Successfully finalized all rewards" + bcolors.ENDC
+
+    # below is to test total rewards query
+    # create another delegator account
+    funder1 = addValidatorWalletAccounts(node_1)
+    delegator1 = createAccount(node_1, 8000000, funder1)
+
+    # delegates some OLT and wait for rewards distribution
+    delegate(node_1, delegator1, '5000000')
+    wait_for(4)
+
+    # initiate 1 withdrawal
+    amt1 = 3
+    withdraw1 = WithdrawRewards(delegator1, amt1, node_1 + "/keystore/")
+    withdraw1.send(True)
+    wait_for(1)
+
+    # finalize withdraw rewards
+    finalize1 = FinalizeRewards(delegator1, node_1 + "/keystore/")
+    wait_for(6)
+    finalize1.send_finalize(str(amt1) + '0' * 18, True)
+
+    # query total rewards and check
+    res = query_rewards(delegator)
+    res1 = query_rewards(delegator1)
+    total = query_total_rewards()
+    check_total_rewards(total['totalRewards'], int(res['balance']) * pow(10, 18) + int(res1['balance']) * pow(10, 18))
+    print bcolors.OKGREEN + "#### Successfully tested query total rewards" + bcolors.ENDC
+
+

--- a/scripts/network_delegation/sdk/actions.py
+++ b/scripts/network_delegation/sdk/actions.py
@@ -254,3 +254,14 @@ def query_rewards(delegator):
     else:
         result = ""
     return result
+
+
+def query_total_rewards():
+    req = {}
+    resp = rpc_call('query.GetTotalDelegRewards', req)
+    print json.dumps(resp, indent=4)
+    if "result" in resp:
+        result = resp["result"]
+    else:
+        result = ""
+    return result

--- a/service/query/network_delegation.go
+++ b/service/query/network_delegation.go
@@ -178,3 +178,18 @@ func (svc *Service) GetDelegRewards(req client.GetDelegRewardsRequest, resp *cli
 	}
 	return nil
 }
+
+func (svc *Service) GetTotalDelegRewards(req client.GetTotalDelegRewardsRequest, resp *client.GetTotalDelegRewardsReply) error {
+	height := svc.netwkDelegators.Rewards.GetState().Version()
+
+	total, err := svc.netwkDelegators.Rewards.GetTotalRewards()
+	if err != nil {
+		return err
+	}
+
+	*resp = client.GetTotalDelegRewardsReply{
+		TotalRewards: *total,
+		Height:  height,
+	}
+	return nil
+}


### PR DESCRIPTION
- added one key pair in store to record total amount of rewards that has been generated
- unit test
- query
- Integration test