### PR TITLE
OLP-1356: Internal Transaction Store is using memDB

### DIFF
--- a/action/governance/expireVotes.go
+++ b/action/governance/expireVotes.go
@@ -43,7 +43,7 @@ func (e ExpireVotes) ProcessCheck(ctx *action.Context, tx action.RawTx) (bool, a
 }
 
 func (e ExpireVotes) ProcessDeliver(ctx *action.Context, tx action.RawTx) (bool, action.Response) {
-	ctx.Logger.Detail("Processing ExpireVotes Transaction for DeliverTx", tx)
+	ctx.Logger.Debug("Processing ExpireVotes Transaction for DeliverTx", tx)
 	return runExpireVotes(ctx, tx)
 }
 

--- a/app/controller.go
+++ b/app/controller.go
@@ -163,9 +163,6 @@ func (app *App) blockBeginner() blockBeginner {
 
 		//update the header to current block
 		app.header = req.Header
-		//Adds proposals that meet the requirements to either Expired or Finalizing Keys from transaction store
-		//Transaction store is not part of chainstate ,it just maintains a list of proposals from BlockBeginner to BlockEnder .Gets cleared at each Block Ender
-		AddInternalTX(app.Context.proposalMaster, app.Context.node.ValidatorAddress(), app.header.Height, app.Context.transaction, app.logger)
 		functionList, err := app.Context.extFunctions.Iterate(common.BlockBeginner)
 		functionParam := common.ExtParam{
 			InternalTxStore: app.Context.transaction,

--- a/app/controller.go
+++ b/app/controller.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/Oneledger/protocol/data/governance"
 	"github.com/Oneledger/protocol/data/network_delegation"
 	"github.com/Oneledger/protocol/external_apps/common"
 	"github.com/tendermint/tendermint/libs/kv"
@@ -320,12 +321,10 @@ func (app *App) blockEnder() blockEnder {
 		ethTrackerlog := log.NewLoggerWithPrefix(app.Context.logWriter, "ethtracker").WithLevel(log.Level(app.Context.cfg.Node.LogLevel))
 		doTransitions(app.Context.jobStore, app.Context.btcTrackers.WithState(app.Context.deliver), app.Context.validators)
 		doEthTransitions(app.Context.jobStore, app.Context.ethTrackers, app.Context.node.ValidatorAddress(), ethTrackerlog, app.Context.witnesses, app.Context.deliver)
-		// Proposals currently in store are cleared if deliver is successful
-		// If Expire or Finalize TX returns false,they will added to the proposals queue in the next block
-		// Errors are logged at the function level
-		// These functions iterate the transactions store
-		ExpireProposals(&app.header, &app.Context, app.logger)
-		FinalizeProposals(&app.header, &app.Context, app.logger)
+
+		//Trigger internal transactions to Expire or Finalize Proposals if necessary
+		updateProposals(app.Context.proposalMaster, app.Context.jobStore, app.Context.deliver)
+
 		functionList, err := app.Context.extFunctions.Iterate(common.BlockEnder)
 		functionParam := common.ExtParam{
 			InternalTxStore: app.Context.transaction,
@@ -838,6 +837,66 @@ func matureDelegationRewards(appCtx *context, req *RequestBeginBlock, kvMap map[
 		kvMap[rewardsKey] = kv.Pair{
 			Key:   []byte(rewardsKey),
 			Value: []byte(coin.String()),
+		}
+		return false
+	})
+}
+
+func updateProposals(proposalMaster *governance.ProposalMasterStore, jobStore *jobs.JobStore, deliver *storage.State) {
+	//Iterate through all active proposals
+	proposals := proposalMaster.Proposal.WithState(deliver)
+	activeProposals := proposals.WithPrefixType(governance.ProposalStateActive)
+
+	activeProposals.Iterate(func(id governance.ProposalID, proposal *governance.Proposal) bool {
+		height := deliver.Version()
+		//If the proposal is in Voting state and voting period expired, trigger internal tx to handle expiry
+		if proposal.Status == governance.ProposalStatusVoting && proposal.VotingDeadline < height {
+
+			//Create New Job to Expire the votes for current proposal
+			checkVotesJob := event.NewGovCheckVotesJob(proposal.ProposalID, proposal.Status)
+
+			//Check if the Job already exists
+			exists, _ := jobStore.WithChain(chain.ONELEDGER).JobExists(checkVotesJob.JobID)
+			if !exists {
+
+				//Save Job to OneLedger Job Store
+				err := jobStore.WithChain(chain.ONELEDGER).SaveJob(checkVotesJob)
+				if err != nil {
+					return true
+				}
+			}
+		}
+
+		return false
+	})
+
+	passedProposals := proposals.WithPrefixType(governance.ProposalStatePassed)
+	passedProposals.Iterate(func(id governance.ProposalID, proposal *governance.Proposal) bool {
+		if proposal.Status == governance.ProposalStatusCompleted && proposal.Outcome == governance.ProposalOutcomeCompletedYes {
+			finalizeJob := event.NewGovFinalizeProposalJob(proposal.ProposalID, proposal.Status)
+
+			exists, _ := jobStore.WithChain(chain.ONELEDGER).JobExists(finalizeJob.JobID)
+			if !exists {
+				err := jobStore.WithChain(chain.ONELEDGER).SaveJob(finalizeJob)
+				if err != nil {
+					return true
+				}
+			}
+		}
+		return false
+	})
+	failedProposals := proposals.WithPrefixType(governance.ProposalStateFailed)
+	failedProposals.Iterate(func(id governance.ProposalID, proposal *governance.Proposal) bool {
+		if proposal.Status == governance.ProposalStatusCompleted && proposal.Outcome == governance.ProposalOutcomeCompletedNo {
+			finalizeJob := event.NewGovFinalizeProposalJob(proposal.ProposalID, proposal.Status)
+
+			exists, _ := jobStore.WithChain(chain.ONELEDGER).JobExists(finalizeJob.JobID)
+			if !exists {
+				err := jobStore.WithChain(chain.ONELEDGER).SaveJob(finalizeJob)
+				if err != nil {
+					return true
+				}
+			}
 		}
 		return false
 	})

--- a/scripts/governance/expireProposal.py
+++ b/scripts/governance/expireProposal.py
@@ -10,6 +10,12 @@ _funding_goal = (int("10") * 10 ** 9)
 _each_funding = (int("5") * 10 ** 9)
 
 
+def withdraw_fund(pid, funder, amount, beneficiary):
+    fund_withdraw = ProposalFundsWithdraw(pid, funder, amount, beneficiary)
+    fund_withdraw.withdraw_fund(funder)
+    time.sleep(2)
+
+
 def expired_votes():
     _prop = Proposal(_pid1, "general", "proposal for vote expired", "proposal headline", _proposer, _initial_funding)
 
@@ -44,6 +50,7 @@ def expire_funding():
 
     # 1st fund
     fund_proposal(encoded_pid, _each_funding, addr_list[0])
+    return encoded_pid, _each_funding
 
 
 def show_proposals():
@@ -62,9 +69,14 @@ def show_proposals():
 
 if __name__ == "__main__":
 
-    expire_funding()
+    pid, funds = expire_funding()
     show_proposals()
 
     expired_votes()
     time.sleep(31)
+
+    print "#### WITHDRAWING: ####"
+    withdraw_fund(pid, _proposer, funds, _proposer)
+    time.sleep(5)
+
     show_proposals()

--- a/scripts/governance/expireProposal.py
+++ b/scripts/governance/expireProposal.py
@@ -34,8 +34,8 @@ def expired_votes():
     check_proposal_state(encoded_pid, ProposalOutcomeInProgress, ProposalStatusVoting)
 
 
-def completed_votes():
-    _prop = Proposal(_pid, "general", "proposal for vote", "proposal headline", _proposer, _initial_funding)
+def expire_funding():
+    _prop = Proposal(_pid, "general", "proposal for insufficient funds", "proposal headline", _proposer, _initial_funding)
 
     # create proposal
     _prop.send_create()
@@ -44,26 +44,6 @@ def completed_votes():
 
     # 1st fund
     fund_proposal(encoded_pid, _each_funding, addr_list[0])
-
-    # 2nd fund
-    fund_proposal(encoded_pid, _each_funding, addr_list[1])
-    check_proposal_state(encoded_pid, ProposalOutcomeInProgress, ProposalStatusVoting)
-
-    # 1st vote --> 25%
-    vote_proposal(encoded_pid, OPIN_POSITIVE, url_0, addr_list[0])
-    check_proposal_state(encoded_pid, ProposalOutcomeInProgress, ProposalStatusVoting)
-
-    # 2nd vote --> 25%
-    vote_proposal(encoded_pid, OPIN_NEGATIVE, url_1, addr_list[1])
-    check_proposal_state(encoded_pid, ProposalOutcomeInProgress, ProposalStatusVoting)
-
-    # 3rd vote --> 50%
-    vote_proposal(encoded_pid, OPIN_POSITIVE, url_2, addr_list[2])
-    check_proposal_state(encoded_pid, ProposalOutcomeInProgress, ProposalStatusVoting)
-
-    # 4th vote --> 75%
-    vote_proposal(encoded_pid, OPIN_POSITIVE, url_3, addr_list[2])
-    check_proposal_state(encoded_pid, ProposalOutcomeCompletedYes, ProposalStatusCompleted)
 
 
 def show_proposals():
@@ -82,7 +62,7 @@ def show_proposals():
 
 if __name__ == "__main__":
 
-    completed_votes()
+    expire_funding()
     show_proposals()
 
     expired_votes()

--- a/scripts/governance/finalizeProposalFail.py
+++ b/scripts/governance/finalizeProposalFail.py
@@ -42,3 +42,13 @@ if __name__ == "__main__":
     if len(pList) == 0:
         print "Exiting Proposal was not finalized"
         sys.exit(1)
+
+    print "PassedProposals ###############"
+    print query_proposals(ProposalStatePassed)
+
+    print "FailedProposals ################"
+    print query_proposals(ProposalStateFailed)
+
+    print "FinalizedProposlals ################"
+    pList = query_proposals(ProposalStateFinalized)
+    print pList


### PR DESCRIPTION
1. Reverted Logic to finalize and expire proposals back to broadcasting internal transactions as the ticket mentioned.
2. Changed the Internal Tx database to use the file system instead of MemDB. This only seems to be used by external apps module.
3. Updated some of the governance test scripts. 