### PR TITLE
OLP-1358: Remove Blockstore from rewards cumulative DB

### DIFF
--- a/app/application.go
+++ b/app/application.go
@@ -456,7 +456,7 @@ func (app *App) Prepare() error {
 	app.Context.witnesses.Init(chain.ETHEREUM, app.Context.node.ValidatorAddress())
 
 	// Init reward cumulative store
-	app.Context.rewardMaster.RewardCm.Init(app.node.BlockStore())
+	app.Context.rewardMaster.RewardCm.Init(genesisDoc.GenesisTime)
 
 	// Initialize internal Services
 	app.Context.internalService = event.NewService(app.Context.node,

--- a/app/application.go
+++ b/app/application.go
@@ -456,7 +456,7 @@ func (app *App) Prepare() error {
 	app.Context.witnesses.Init(chain.ETHEREUM, app.Context.node.ValidatorAddress())
 
 	// Init reward cumulative store
-	app.Context.rewardMaster.RewardCm.Init(genesisDoc.GenesisTime)
+	app.Context.rewardMaster.RewardCm.Init(genesisDoc.GenesisTime.UTC())
 
 	// Initialize internal Services
 	app.Context.internalService = event.NewService(app.Context.node,

--- a/app/controller.go
+++ b/app/controller.go
@@ -614,7 +614,7 @@ func handleBlockRewards(appCtx *context, block RequestBeginBlock, logger *log.Lo
 	if err != nil {
 		return abciTypes.Event{}
 	}
-	totalRewards, err := rewardMaster.RewardCm.PullRewards(lastHeight, block.Header.Time, rewardPoolCoin.Amount)
+	totalRewards, err := rewardMaster.RewardCm.PullRewards(lastHeight, block.Header.Time.UTC(), rewardPoolCoin.Amount)
 	if err != nil {
 		return abciTypes.Event{}
 	}

--- a/app/controller.go
+++ b/app/controller.go
@@ -614,7 +614,7 @@ func handleBlockRewards(appCtx *context, block RequestBeginBlock, logger *log.Lo
 	if err != nil {
 		return abciTypes.Event{}
 	}
-	totalRewards, err := rewardMaster.RewardCm.PullRewards(lastHeight, rewardPoolCoin.Amount)
+	totalRewards, err := rewardMaster.RewardCm.PullRewards(lastHeight, block.Header.Time, rewardPoolCoin.Amount)
 	if err != nil {
 		return abciTypes.Event{}
 	}

--- a/data/rewards/calculator.go
+++ b/data/rewards/calculator.go
@@ -112,8 +112,8 @@ func (calc *RewardCalculator) Calculate() (amt *balance.Amount, err error) {
 		logger.Errorf("Year rewards burned out unexpectedly, year= %v", year+1)
 		return
 	}
-	fmt.Println("yearleft: ", yearLeft)
-	fmt.Println("numofMoreBlocks: ", numofMoreBlocks)
+	//fmt.Println("yearleft: ", yearLeft)
+	//fmt.Println("numofMoreBlocks: ", numofMoreBlocks)
 	// calculate rewards per block
 	amt = balance.NewAmountFromBigInt(big.NewInt(0).Div(yearLeft.BigInt(), big.NewInt(numofMoreBlocks)))
 	calc.cacheResult(year, cycleNo, amt, false)
@@ -128,9 +128,9 @@ func (calc *RewardCalculator) secondsPerCycleLatest() (int64, time.Time) {
 		cycle := calc.options.BlockSpeedCalculateCycle
 		cycleEndHeight := calc.height
 		cycleBeginHeight := cycleEndHeight - cycle
-		fmt.Println("cycleBeginHeight: ", cycleBeginHeight)
-		fmt.Println("calc.height: ", calc.height)
-		fmt.Println("BlockSpeedCalculateCycle: ", cycle)
+		//fmt.Println("cycleBeginHeight: ", cycleBeginHeight)
+		//fmt.Println("calc.height: ", calc.height)
+		//fmt.Println("BlockSpeedCalculateCycle: ", cycle)
 		// duration of the cycle, in secs
 		timestamp, err := calc.GetTimeStamp(cycleBeginHeight)
 		if err != nil {
@@ -142,8 +142,8 @@ func (calc *RewardCalculator) secondsPerCycleLatest() (int64, time.Time) {
 		tBegin := timestamp.UTC()
 		tEnd = calc.currentBlockTime.UTC()
 
-		fmt.Println("begin: ", tBegin)
-		fmt.Println("end: ", tEnd)
+		//fmt.Println("begin: ", tBegin)
+		//fmt.Println("end: ", tEnd)
 
 		//Save Current block timestamp as Beginning of new cycle
 		err = calc.SaveTimeStamp(calc.height, &calc.currentBlockTime)
@@ -209,7 +209,7 @@ func (calc *RewardCalculator) Init(genesisTime time.Time) {
 // Set cumulative amount(s) by key
 func (calc *RewardCalculator) set(key storage.StoreKey, obj interface{}) error {
 	dat, err := calc.szlr.Serialize(obj)
-	fmt.Println("saveTimestamp Key: ", key)
+	//fmt.Println("saveTimestamp Key: ", key)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (calc *RewardCalculator) set(key storage.StoreKey, obj interface{}) error {
 // Get Timestamp by key
 func (calc *RewardCalculator) getTimestamp(key storage.StoreKey) (timestamp *time.Time, err error) {
 	timestamp = &time.Time{}
-	fmt.Println("getTimestamp Key: ", key)
+	//fmt.Println("getTimestamp Key: ", key)
 	dat, err := calc.state.Get(key)
 	if err != nil {
 		return

--- a/data/rewards/calculator.go
+++ b/data/rewards/calculator.go
@@ -125,7 +125,7 @@ func (calc *RewardCalculator) secondsPerCycleLatest() (int64, time.Time) {
 	if calc.height > calc.options.BlockSpeedCalculateCycle {
 		// get speed calculation [begin, end] height
 		cycle := calc.options.BlockSpeedCalculateCycle
-		cycleEndHeight := calc.height
+		cycleEndHeight := (calc.height-1)/cycle*cycle + 1
 		cycleBeginHeight := cycleEndHeight - cycle
 
 		timestamp, err := calc.GetTimeStamp(cycleBeginHeight)

--- a/data/rewards/calculator.go
+++ b/data/rewards/calculator.go
@@ -112,8 +112,7 @@ func (calc *RewardCalculator) Calculate() (amt *balance.Amount, err error) {
 		logger.Errorf("Year rewards burned out unexpectedly, year= %v", year+1)
 		return
 	}
-	//fmt.Println("yearleft: ", yearLeft)
-	//fmt.Println("numofMoreBlocks: ", numofMoreBlocks)
+
 	// calculate rewards per block
 	amt = balance.NewAmountFromBigInt(big.NewInt(0).Div(yearLeft.BigInt(), big.NewInt(numofMoreBlocks)))
 	calc.cacheResult(year, cycleNo, amt, false)
@@ -128,22 +127,15 @@ func (calc *RewardCalculator) secondsPerCycleLatest() (int64, time.Time) {
 		cycle := calc.options.BlockSpeedCalculateCycle
 		cycleEndHeight := calc.height
 		cycleBeginHeight := cycleEndHeight - cycle
-		//fmt.Println("cycleBeginHeight: ", cycleBeginHeight)
-		//fmt.Println("calc.height: ", calc.height)
-		//fmt.Println("BlockSpeedCalculateCycle: ", cycle)
-		// duration of the cycle, in secs
+
 		timestamp, err := calc.GetTimeStamp(cycleBeginHeight)
 		if err != nil {
 			fmt.Println("ERROR READING TIMESTAMP: ", err.Error())
 			return 0, time.Time{}
 		}
-
 		//Get Start and End timestamps for current cycle
 		tBegin := timestamp.UTC()
 		tEnd = calc.currentBlockTime.UTC()
-
-		//fmt.Println("begin: ", tBegin)
-		//fmt.Println("end: ", tEnd)
 
 		//Save Current block timestamp as Beginning of new cycle
 		err = calc.SaveTimeStamp(calc.height, &calc.currentBlockTime)
@@ -209,7 +201,6 @@ func (calc *RewardCalculator) Init(genesisTime time.Time) {
 // Set cumulative amount(s) by key
 func (calc *RewardCalculator) set(key storage.StoreKey, obj interface{}) error {
 	dat, err := calc.szlr.Serialize(obj)
-	//fmt.Println("saveTimestamp Key: ", key)
 	if err != nil {
 		return err
 	}
@@ -220,7 +211,6 @@ func (calc *RewardCalculator) set(key storage.StoreKey, obj interface{}) error {
 // Get Timestamp by key
 func (calc *RewardCalculator) getTimestamp(key storage.StoreKey) (timestamp *time.Time, err error) {
 	timestamp = &time.Time{}
-	//fmt.Println("getTimestamp Key: ", key)
 	dat, err := calc.state.Get(key)
 	if err != nil {
 		return

--- a/data/rewards/calculator.go
+++ b/data/rewards/calculator.go
@@ -151,7 +151,6 @@ func (calc *RewardCalculator) secondsPerCycleLatest() (int64, time.Time) {
 // return 0 blocks if all rewards years burned out
 func (calc *RewardCalculator) numofMoreBlocksBeforeYearClose() (int64, int) {
 	secsPerCycle, tCycleEnd := calc.secondsPerCycleLatest()
-	fmt.Println("secondsPerCycleLatest: ", secsPerCycle)
 
 	numofMoreBlocks := int64(0)
 	yearIndex := -1

--- a/data/rewards/calculator_test.go
+++ b/data/rewards/calculator_test.go
@@ -1,0 +1,64 @@
+package rewards
+
+/*
+import "time"
+
+
+import (
+	"fmt"
+	"github.com/Oneledger/protocol/storage"
+	"github.com/stretchr/testify/assert"
+	db "github.com/tendermint/tm-db"
+	"testing"
+	"time"
+)
+
+const (
+	prefix = "rewcml"
+)
+
+var (
+	calculator                   *RewardCalculator
+	estimatedsecondspercycleCalc = int64(1728)
+	blockspeedcalculatecycleCalc = int64(4)
+	options                      *Options
+	genesisTime                  time.Time
+	rewardYears                  RewardYears
+)
+
+func init() {
+	//Create Test DB
+	newDB := db.NewDB("test", db.MemDBBackend, "")
+	cs := storage.NewState(storage.NewChainState("chainstate", newDB))
+	genesisTime = time.Now()
+	options = &Options{}
+	options.BlockSpeedCalculateCycle = blockspeedcalculatecycleCalc
+	options.EstimatedSecondsPerCycle = estimatedsecondspercycleCalc
+
+	rewardYears = RewardYears{Years: []RewardYear{}}
+
+	calculator = NewRewardCalculator(cs, prefix)
+	calculator.SetOptions(options)
+	calculator.Init(genesisTime)
+}
+
+func TestRewardCalculator_secondsPerCycleLatest(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		time := time.Now()
+		calculator.Reset(int64(i+1), time, rewardYears)
+		height, endtime := calculator.secondsPerCycleLatest()
+		fmt.Println("height: ", height, "endtime: ", endtime)
+	}
+
+}
+
+func TestRewardCalculator_SaveTimeStamp(t *testing.T) {
+	timestamp := time.Now()
+	err := calculator.SaveTimeStamp(100, timestamp)
+	assert.Equal(t, nil, err)
+
+	query, err := calculator.GetTimeStamp(100)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, timestamp, query)
+}
+*/

--- a/data/rewards/calculator_test.go
+++ b/data/rewards/calculator_test.go
@@ -1,11 +1,6 @@
 package rewards
 
-/*
-import "time"
-
-
 import (
-	"fmt"
 	"github.com/Oneledger/protocol/storage"
 	"github.com/stretchr/testify/assert"
 	db "github.com/tendermint/tm-db"
@@ -43,22 +38,21 @@ func init() {
 }
 
 func TestRewardCalculator_secondsPerCycleLatest(t *testing.T) {
-	for i := 0; i < 20; i++ {
-		time := time.Now()
-		calculator.Reset(int64(i+1), time, rewardYears)
-		height, endtime := calculator.secondsPerCycleLatest()
-		fmt.Println("height: ", height, "endtime: ", endtime)
-	}
+	//for i := 0; i < 20; i++ {
+	//	time := time.Now()
+	//	calculator.Reset(int64(i+1), time, rewardYears)
+	//	height, endtime := calculator.secondsPerCycleLatest()
+	//	fmt.Println("height: ", height, "endtime: ", endtime)
+	//}
 
 }
 
 func TestRewardCalculator_SaveTimeStamp(t *testing.T) {
-	timestamp := time.Now()
-	err := calculator.SaveTimeStamp(100, timestamp)
+	timestamp := time.Now().UTC()
+	err := calculator.SaveTimeStamp(100, &timestamp)
 	assert.Equal(t, nil, err)
 
 	query, err := calculator.GetTimeStamp(100)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, timestamp, query)
+	assert.EqualValues(t, &timestamp, query)
 }
-*/

--- a/data/rewards/calculator_test.go
+++ b/data/rewards/calculator_test.go
@@ -14,6 +14,7 @@ const (
 
 var (
 	calculator                   *RewardCalculator
+	estimatedSecondsPerBlockCalc = int64(17280)
 	estimatedsecondspercycleCalc = int64(1728)
 	blockspeedcalculatecycleCalc = int64(4)
 	options                      *Options
@@ -35,16 +36,6 @@ func init() {
 	calculator = NewRewardCalculator(cs, prefix)
 	calculator.SetOptions(options)
 	calculator.Init(genesisTime)
-}
-
-func TestRewardCalculator_secondsPerCycleLatest(t *testing.T) {
-	//for i := 0; i < 20; i++ {
-	//	time := time.Now()
-	//	calculator.Reset(int64(i+1), time, rewardYears)
-	//	height, endtime := calculator.secondsPerCycleLatest()
-	//	fmt.Println("height: ", height, "endtime: ", endtime)
-	//}
-
 }
 
 func TestRewardCalculator_SaveTimeStamp(t *testing.T) {

--- a/data/rewards/calculator_test.go
+++ b/data/rewards/calculator_test.go
@@ -40,10 +40,22 @@ func init() {
 
 func TestRewardCalculator_SaveTimeStamp(t *testing.T) {
 	timestamp := time.Now().UTC()
-	err := calculator.SaveTimeStamp(100, &timestamp)
+	err := calculator.SaveTimeStamp(100, timestamp)
 	assert.Equal(t, nil, err)
 
 	query, err := calculator.GetTimeStamp(100)
 	assert.Equal(t, nil, err)
 	assert.EqualValues(t, &timestamp, query)
+}
+
+func TestRewardCalculator_GetCycleTime(t *testing.T) {
+	timestamp := time.Now().UTC()
+	err := calculator.SaveTimeStamp(1, timestamp)
+	assert.Equal(t, nil, err)
+	timestamp2 := timestamp.Add(time.Duration(estimatedSecondsPerCycle) * time.Second)
+	err = calculator.SaveTimeStamp(2, timestamp2)
+	assert.Equal(t, nil, err)
+
+	seconds := calculator.GetCycleTime(2)
+	assert.Equal(t, estimatedSecondsPerCycle, seconds)
 }

--- a/data/rewards/store_cumulative.go
+++ b/data/rewards/store_cumulative.go
@@ -31,6 +31,7 @@ func NewRewardCumulativeStore(prefix string, state *storage.State) *RewardCumula
 
 func (rws *RewardCumulativeStore) WithState(state *storage.State) *RewardCumulativeStore {
 	rws.state = state
+	rws.calculator.state = state
 	return rws
 }
 

--- a/data/rewards/store_cumulative.go
+++ b/data/rewards/store_cumulative.go
@@ -2,7 +2,7 @@ package rewards
 
 import (
 	"github.com/pkg/errors"
-	tmstore "github.com/tendermint/tendermint/store"
+	"time"
 
 	"github.com/Oneledger/protocol/data/balance"
 	"github.com/Oneledger/protocol/data/keys"
@@ -16,7 +16,7 @@ type RewardCumulativeStore struct {
 	prefix []byte
 
 	calculator    *RewardCalculator
-	blockStore    *tmstore.BlockStore
+	genesisTime   time.Time
 	rewardOptions *Options
 }
 
@@ -25,7 +25,7 @@ func NewRewardCumulativeStore(prefix string, state *storage.State) *RewardCumula
 		state:      state,
 		prefix:     storage.Prefix(prefix),
 		szlr:       serialize.GetSerializer(serialize.PERSISTENT),
-		calculator: NewRewardCalculator(),
+		calculator: NewRewardCalculator(state, prefix),
 	}
 }
 
@@ -35,7 +35,7 @@ func (rws *RewardCumulativeStore) WithState(state *storage.State) *RewardCumulat
 }
 
 // Pull a combined block rewards from total supply for all voting validators for given block height
-func (rws *RewardCumulativeStore) PullRewards(height int64, poolAmt *balance.Amount) (amount *balance.Amount, err error) {
+func (rws *RewardCumulativeStore) PullRewards(height int64, currentTime time.Time, poolAmt *balance.Amount) (amount *balance.Amount, err error) {
 	// get year distributed amount till now
 	rewardYears, err := rws.GetYearDistributedRewards()
 	if err != nil {
@@ -43,7 +43,7 @@ func (rws *RewardCumulativeStore) PullRewards(height int64, poolAmt *balance.Amo
 	}
 
 	// calculate reward for each block
-	rws.calculator.Reset(height, rewardYears)
+	rws.calculator.Reset(height, currentTime, rewardYears)
 	amount, err = rws.calculator.Calculate()
 	if err != nil {
 		return
@@ -175,9 +175,9 @@ func (rws *RewardCumulativeStore) GetOptions() *Options {
 	return rws.rewardOptions
 }
 
-func (rws *RewardCumulativeStore) Init(blockStore *tmstore.BlockStore) {
-	rws.blockStore = blockStore
-	rws.calculator.Init(blockStore)
+func (rws *RewardCumulativeStore) Init(genesisTime time.Time) {
+	rws.genesisTime = genesisTime
+	rws.calculator.Init(genesisTime)
 }
 
 //-----------------------------helper functions
@@ -251,7 +251,7 @@ func (rws *RewardCumulativeStore) getRewardYears(key storage.StoreKey) (rewards 
 
 // Initialize each reward year's information
 func (rws *RewardCumulativeStore) initRewardYears(key storage.StoreKey) (rewards RewardYears, err error) {
-	tStart := rws.blockStore.LoadBlockMeta(1).Header.Time.UTC()
+	tStart := rws.genesisTime.UTC()
 	numofYears := len(rws.rewardOptions.YearBlockRewardShares)
 
 	// calculate each year's start/close time

--- a/data/rewards/store_cumulative_test.go
+++ b/data/rewards/store_cumulative_test.go
@@ -10,9 +10,6 @@ import (
 	"testing"
 	"time"
 
-	tmstore "github.com/tendermint/tendermint/store"
-	"github.com/tendermint/tendermint/types"
-
 	"github.com/stretchr/testify/assert"
 	db "github.com/tendermint/tm-db"
 
@@ -53,11 +50,11 @@ var (
 		*yearBlockRewardShare_4,
 		*yearBlockRewardShare_5,
 	}
-	yearBlockRewardDist_1, _ = balance.NewAmountFromString("68441850", 10)
-	yearBlockRewardDist_2, _ = balance.NewAmountFromString("70058400", 10)
-	yearBlockRewardDist_3, _ = balance.NewAmountFromString("39384025", 10)
-	yearBlockRewardDist_4, _ = balance.NewAmountFromString("39967950", 10)
-	yearBlockRewardDist_5, _ = balance.NewAmountFromString("29421575", 10)
+	yearBlockRewardDist_1, _ = balance.NewAmountFromString("68418125", 10)
+	yearBlockRewardDist_2, _ = balance.NewAmountFromString("69771125", 10)
+	yearBlockRewardDist_3, _ = balance.NewAmountFromString("39095550", 10)
+	yearBlockRewardDist_4, _ = balance.NewAmountFromString("39710750", 10)
+	yearBlockRewardDist_5, _ = balance.NewAmountFromString("30433875", 10)
 	yearBlockRewardDist      = []balance.Amount{
 		*yearBlockRewardDist_1,
 		*yearBlockRewardDist_2,
@@ -75,36 +72,6 @@ var (
 		BurnoutRate:              *burnoutRate,
 	}
 )
-
-func makeFakeBlock(blockStore *tmstore.BlockStore, height int64, bftTime time.Time) *types.Block {
-	header := types.Header{Height: height, Time: bftTime}
-	block := &types.Block{Header: header, LastCommit: &types.Commit{}}
-	blockStore.SaveBlock(block, &types.PartSet{}, &types.Commit{})
-	return block
-}
-
-//func setupBlockStore(years int) time.Time {
-//	blockStore := tmstore.NewBlockStore(memDb)
-//
-//	// seed
-//	tNow := time.Now().UTC()
-//	tStart := tNow
-//	rand.Seed(1)
-//
-//	// simulates randomly generating at approximately 0.2day(4.3~5.3hours) per block
-//	secsPerBlock := int64(estimatedSecondsPerBlock)
-//	numofBlocks := 2000 * years
-//	for i := 0; i < numofBlocks; i++ { // generate enough blocks for 5 years
-//		secs := int64(0)
-//		if i > 0 {
-//			secs = secsPerBlock + rand.Int63n(3600) - 1800
-//			tNow = tNow.Add(time.Second * time.Duration(secs))
-//		}
-//		makeFakeBlock(blockStore, int64(i+1), tNow)
-//	}
-//	store.Init(tNow)
-//	return tStart
-//}
 
 func setupRewardYears(tStart time.Time) RewardYears {
 	numofYears := len(store.rewardOptions.YearBlockRewardShares)
@@ -193,7 +160,7 @@ func TestRewardsCumulativeStore_PullRewards(t *testing.T) {
 	years := setupRewardYears(tStart)
 
 	// check pulled reward amount for 5 years
-	for i := 1; i <= 9100; i++ {
+	for i := 1; i <= 9150; i++ {
 		height := int64(i)
 		time := tStart.Add(time.Second * time.Duration(height*estimatedSecondsPerBlock))
 		amount, err := store.PullRewards(height, time, balance.NewAmount(0))
@@ -223,14 +190,15 @@ func TestRewardsCumulativeStore_PullRewards(t *testing.T) {
 	}
 
 	// test burnout, pool has nothing
-	height := int64(9101)
+	height := int64(9151)
 	timeCurr := tStart.Add(time.Second * time.Duration(height*estimatedSecondsPerBlock))
 	amount, err := store.PullRewards(height, timeCurr, balance.NewAmount(0))
 	assert.Nil(t, err)
+	fmt.Println("Amount height 9101: ", amount)
 	assert.True(t, zero.Equals(*amount))
 
 	// test burnout, pool amount < burnout rate
-	height = int64(9102)
+	height = int64(9152)
 	timeCurr = tStart.Add(time.Second * time.Duration(height*estimatedSecondsPerBlock))
 	amount, err = store.PullRewards(height, timeCurr, balance.NewAmount(4))
 	assert.Nil(t, err)
@@ -238,7 +206,7 @@ func TestRewardsCumulativeStore_PullRewards(t *testing.T) {
 	assert.True(t, store.calculator.Burnedout())
 
 	// test burnout, pool amount >= burnout rate
-	height = int64(9103)
+	height = int64(9153)
 	timeCurr = tStart.Add(time.Second * time.Duration(height*estimatedSecondsPerBlock))
 	amount, err = store.PullRewards(height, timeCurr, balance.NewAmount(6))
 	assert.Nil(t, err)


### PR DESCRIPTION
1. Removed Block Store from rewards cumulative db
2. Used Genesis time for initialization
3. Passed current block time as argument in block beginner
4. Refactored Unit tests