### PR TITLE
OLP-1426: Saved Witnesses as separate section in genesis file

### DIFF
--- a/app/application.go
+++ b/app/application.go
@@ -199,8 +199,8 @@ func (app *App) setupState(stateBytes []byte) error {
 			return errors.Wrap(err, "failed to set balance")
 		}
 	}
-	for _, stake := range initial.Witness {
-		err = app.Context.witnesses.WithState(app.Context.deliver).AddWitness(chain.ETHEREUM, identity.Stake(stake))
+	for _, witness := range initial.Witness {
+		err = app.Context.witnesses.WithState(app.Context.deliver).AddWitness(chain.ETHEREUM, witness)
 		if err != nil {
 			return errors.Wrap(err, "failed to add initial ethereum witness")
 		}

--- a/app/context.go
+++ b/app/context.go
@@ -346,6 +346,7 @@ type StorageCtx struct {
 	Balances        *balance.Store
 	Domains         *ons.DomainStore
 	Validators      *identity.ValidatorStore // Set of validators currently active
+	Witnesses       *identity.WitnessStore
 	Delegators      *delegation.DelegationStore
 	RewardMaster    *rewards.RewardMasterStore
 	ProposalMaster  *governance.ProposalMasterStore
@@ -370,6 +371,7 @@ func (ctx *context) Storage() StorageCtx {
 		Balances:        ctx.balances,
 		Domains:         ctx.domains,
 		Validators:      ctx.validators,
+		Witnesses:       ctx.witnesses,
 		Delegators:      ctx.delegators,
 		RewardMaster:    ctx.rewardMaster,
 		ProposalMaster:  ctx.proposalMaster,

--- a/cmd/olfullnode/devnet.go
+++ b/cmd/olfullnode/devnet.go
@@ -578,6 +578,7 @@ func initialState(args *testnetConfig, nodeList []node, option ethchain.ChainDri
 	}
 	balances := make([]consensus.BalanceState, 0, len(nodeList))
 	staking := make([]consensus.Stake, 0, len(nodeList))
+	witnesses := make([]identity.Witness, 0, len(nodeList))
 	penalities := make([]identity.Penalty, 0)
 	rewards := rewards.RewardMasterState{
 		RewardState: rewards.NewRewardState(),
@@ -667,7 +668,14 @@ func initialState(args *testnetConfig, nodeList []node, option ethchain.ChainDri
 			Name:             node.validator.Name,
 			Amount:           *balance.NewAmountFromInt(node.validator.Power),
 		}
+		wt := identity.Witness{
+			Address:     node.validator.Address.Bytes(),
+			PubKey:      pubkey,
+			ECDSAPubKey: h.PubKey(),
+			Name:        node.validator.Name,
+		}
 		staking = append(staking, st)
+		witnesses = append(witnesses, wt)
 	}
 	if len(args.initialTokenHolders) > 0 {
 		for _, acct := range initialAddrs {
@@ -732,7 +740,7 @@ func initialState(args *testnetConfig, nodeList []node, option ethchain.ChainDri
 		Balances:   balances,
 		Staking:    staking,
 		Penalties:  penalities,
-		Witness:    staking,
+		Witness:    witnesses,
 		Rewards:    rewards,
 		Domains:    domains,
 		Fees:       fees_db,

--- a/cmd/olfullnode/save_state.go
+++ b/cmd/olfullnode/save_state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/Oneledger/protocol/data/chain"
 	"io"
 	"os"
 	"path/filepath"
@@ -245,6 +246,8 @@ func writeListWithTag(ctx app.StorageCtx, writer io.Writer, tag string) bool {
 		DumpBalanceToFile(ctx.Balances, writer, writeStruct)
 	case "staking":
 		DumpStakingToFile(ctx.Validators, writer, writeStruct)
+	case "witness":
+		DumpWitnessesToFile(ctx.Witnesses, writer, writeStruct)
 	case "penalties":
 		DumpPenaltyToFile(ctx.Validators, writer, writeStruct)
 	case "domains":
@@ -360,6 +363,7 @@ func SaveChainState(application *app.App, filename string, directory string) err
 	writeStructWithTag(writer, appState.Chain, "state")
 	writeListWithTag(ctx, writer, "balances")
 	writeListWithTag(ctx, writer, "staking")
+	writeListWithTag(ctx, writer, "witness")
 	writeListWithTag(ctx, writer, "penalties")
 	writeStoreWithTag(ctx, writer, "delegation")
 	writeStoreWithTag(ctx, writer, "rewards")
@@ -426,6 +430,24 @@ func DumpStakingToFile(vs *identity.ValidatorStore, writer io.Writer, fn func(wr
 		//stake.Power = validator.Power
 
 		fn(writer, stake)
+		iterator++
+		return false
+	})
+
+	return
+}
+
+func DumpWitnessesToFile(ws *identity.WitnessStore, writer io.Writer, fn func(writer io.Writer, obj interface{}) bool) {
+	iterator := 0
+	delimiter := ","
+	ws.Iterate(chain.ETHEREUM, func(key keys.Address, witness *identity.Witness) bool {
+		if iterator != 0 {
+			_, err := writer.Write([]byte(delimiter))
+			if err != nil {
+				return true
+			}
+		}
+		fn(writer, witness)
 		iterator++
 		return false
 	})

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -85,7 +85,7 @@ type AppState struct {
 	Balances      []BalanceState                 `json:"balances"`
 	Staking       []Stake                        `json:"staking"`
 	Penalties     []identity.Penalty             `json:"penalties"`
-	Witness       []Stake                        `json:"witness"`
+	Witness       []identity.Witness             `json:"witness"`
 	Delegation    delegation.DelegationState     `json:"delegation"`
 	Rewards       rewards.RewardMasterState      `json:"rewards"`
 	Domains       []DomainState                  `json:"domains"`
@@ -101,7 +101,7 @@ func NewAppState(currencies balance.Currencies,
 	balances []BalanceState,
 	staking []Stake,
 	penalties []identity.Penalty,
-	witness []Stake,
+	witness []identity.Witness,
 	delegation delegation.DelegationState,
 	rewards rewards.RewardMasterState,
 	domains []DomainState,

--- a/data/rewards/store_cumulative_test.go
+++ b/data/rewards/store_cumulative_test.go
@@ -52,8 +52,8 @@ var (
 	}
 	yearBlockRewardDist_1, _ = balance.NewAmountFromString("68418125", 10)
 	yearBlockRewardDist_2, _ = balance.NewAmountFromString("69771125", 10)
-	yearBlockRewardDist_3, _ = balance.NewAmountFromString("39095550", 10)
-	yearBlockRewardDist_4, _ = balance.NewAmountFromString("39710750", 10)
+	yearBlockRewardDist_3, _ = balance.NewAmountFromString("40578450", 10)
+	yearBlockRewardDist_4, _ = balance.NewAmountFromString("39703550", 10)
 	yearBlockRewardDist_5, _ = balance.NewAmountFromString("30433875", 10)
 	yearBlockRewardDist      = []balance.Amount{
 		*yearBlockRewardDist_1,

--- a/identity/eth_witness_set.go
+++ b/identity/eth_witness_set.go
@@ -88,16 +88,9 @@ func (ws *WitnessStore) IsWitnessAddress(chain chain.Type, addr keys.Address) bo
 }
 
 // Add a witness to store
-func (ws *WitnessStore) AddWitness(chain chain.Type, apply Stake) error {
-	if ws.Exists(chain, apply.ValidatorAddress) {
+func (ws *WitnessStore) AddWitness(chain chain.Type, witness Witness) error {
+	if ws.Exists(chain, witness.Address) {
 		return nil
-	}
-
-	witness := &Witness{
-		Address:     apply.ValidatorAddress,
-		PubKey:      apply.Pubkey,
-		ECDSAPubKey: apply.ECDSAPubKey,
-		Name:        apply.Name,
 	}
 
 	value := witness.Bytes()

--- a/identity/eth_witness_set_test.go
+++ b/identity/eth_witness_set_test.go
@@ -33,20 +33,18 @@ func setupInitialWitness(ws *WitnessStore) []keys.Address {
 	addresses[2] = addr2
 	addresses[3] = addr3
 
-	stakes := make([]Stake, 2)
-	stakes[0] = Stake{
-		ValidatorAddress: addr0,
-		StakeAddress:     addr0,
-		Pubkey: keys.PublicKey{
+	stakes := make([]Witness, 2)
+	stakes[0] = Witness{
+		Address: addr0,
+		PubKey: keys.PublicKey{
 			KeyType: keys.ED25519,
 			Data:    nil,
 		},
 		Name: "test_node0",
 	}
-	stakes[1] = Stake{
-		ValidatorAddress: addr1,
-		StakeAddress:     addr1,
-		Pubkey: keys.PublicKey{
+	stakes[1] = Witness{
+		Address: addr1,
+		PubKey: keys.PublicKey{
 			KeyType: keys.ED25519,
 			Data:    nil,
 		},
@@ -139,10 +137,9 @@ func TestEthWitnessStore_IsETHWitnessAddress(t *testing.T) {
 func TestEthWitnessStore_AddWitness(t *testing.T) {
 	ws := setupEthWitnessStore()
 	addr, _ := hex.DecodeString("F2143AD5793BA10D9410225ADC68B38D5085E11C")
-	stake := Stake{
-		ValidatorAddress: addr,
-		StakeAddress:     addr,
-		Pubkey: keys.PublicKey{
+	stake := Witness{
+		Address: addr,
+		PubKey: keys.PublicKey{
 			KeyType: keys.ED25519,
 			Data:    nil,
 		},


### PR DESCRIPTION
1. Updated unit tests
2. Refactored function in witness store
3. Dumped the Witnesses separately to the genesis
4. Tested by starting network, 
  - deploying smart contract
  - stopping
  - saving state
  - starting back up
  - performed lock and redeem